### PR TITLE
Adds VScode Task to improve internal workflows

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -56,6 +56,71 @@
             "problemMatcher": []
         },
         {
+            "label": "Configure Monolith",
+            "type": "shell",
+            "command": "cmake",
+            "args": [
+                "--preset",
+                "x64-windows-${input:monolithFlavor}",
+                "-B",
+                "${workspaceFolder}/.cmake-build-monolith-${input:monolithFlavor}",
+                "-DINSTALL_TO_MONOLITH=ON"
+            ],
+            "hide": true,
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Build Monolith",
+            "type": "shell",
+            "command": "cmake",
+            "args": [
+                "--build",
+                "${workspaceFolder}/.cmake-build-monolith-${input:monolithFlavor}",
+                "--config",
+                "${input:monolithFlavor}"
+            ],
+            "hide": true,
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared"
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Install to Monolith",
+            "type": "shell",
+            "command": "cmake",
+            "args": [
+                "--install",
+                "${workspaceFolder}/.cmake-build-monolith-${input:monolithFlavor}",
+                "--config",
+                "${input:monolithFlavor}",
+                "--prefix",
+                "${input:monolithBranchRoot}/vendor/github.com/ccpgames/carbon-audio/develop"
+            ],
+            "dependsOn": [
+                "Configure Monolith",
+                "Build Monolith"
+            ],
+            "dependsOrder": "sequence",
+            "group": "build",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "shared"
+            },
+            "problemMatcher": []
+        },
+        {
             "label": "Clean Build Directory",
             "type": "shell",
             "command": "powershell",
@@ -108,6 +173,28 @@
                 "panel": "shared"
             },
             "problemMatcher": []
+        }
+    ],
+    "inputs": [
+        {
+            "id": "monolithFlavor",
+            "type": "pickString",
+            "description": "Which build flavor to install to the monolith",
+            "options": [
+                "internal",
+                "release",
+                "debug",
+                "trinitydev"
+            ],
+            "default": "internal"
+        },
+        {
+            "id": "monolithBranchRoot",
+            "type": "pickString",
+            "description": "Perforce branch root to install CarbonAudio into",
+            "options": [
+                "C:/Users/phevos/Perforce/phevos_remote_frontier"
+            ]
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -104,7 +104,7 @@
                 "--config",
                 "${input:monolithFlavor}",
                 "--prefix",
-                "${input:monolithBranchRoot}/vendor/github.com/ccpgames/carbon-audio/develop"
+                "${config:carbonAudio.monolithBranchRoot}/vendor/github.com/ccpgames/carbon-audio/develop"
             ],
             "dependsOn": [
                 "Configure Monolith",
@@ -119,6 +119,25 @@
                 "panel": "shared"
             },
             "problemMatcher": []
+        },
+        {
+            "label": "Set Perforce Branch",
+            "type": "shell",
+            "command": "powershell",
+            "args": [
+                "-Command",
+                "$p = '${workspaceFolder}\\.vscode\\settings.json'; $root = '${input:perforceBranchRoot}'; if (Test-Path $p) { $c = Get-Content $p -Raw } else { $c = '' }; if ([string]::IsNullOrWhiteSpace($c)) { $j = [PSCustomObject]@{} } else { $j = $c | ConvertFrom-Json }; $j | Add-Member -NotePropertyName 'carbonAudio.monolithBranchRoot' -NotePropertyValue $root -Force; $j | ConvertTo-Json -Depth 10 | Set-Content -Path $p -Encoding UTF8; Write-Host \"Perforce branch root set to: $root\" -ForegroundColor Green"
+            ],
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared"
+            },
+            "problemMatcher": [],
+            "windows": {
+                "command": "powershell"
+            }
         },
         {
             "label": "Clean Build Directory",
@@ -189,12 +208,10 @@
             "default": "internal"
         },
         {
-            "id": "monolithBranchRoot",
-            "type": "pickString",
+            "id": "perforceBranchRoot",
+            "type": "promptString",
             "description": "Perforce branch root to install CarbonAudio into",
-            "options": [
-                "C:/Users/phevos/Perforce/phevos_remote_frontier"
-            ]
+            "default": "${config:carbonAudio.monolithBranchRoot}"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -104,7 +104,7 @@
                 "--config",
                 "${input:monolithFlavor}",
                 "--prefix",
-                "${config:carbonAudio.monolithBranchRoot}/vendor/github.com/ccpgames/carbon-audio/develop"
+                "${config:carbonAudio.monolithBranchRoot}/vendor/github.com/carbonengine/audio/develop"
             ],
             "dependsOn": [
                 "Configure Monolith",


### PR DESCRIPTION
# Description

After the VCPKG migration and open sourcing of the audio repository, previous internal workflows are now broken.
We still need a quick way to install the carbon-audio component into the monolith and this VScode task does exactly that.

### How to use
1. Hit CTRL+SHIFT+B the task will appear in a drop down menu
2. Select the build preset e.g x64-Internal
3. Next it will ask for a monolith root path e.g p4v/user/frontier_branch1

that's it, should build and install for you.