### PR TITLE
Port fixes from release/7.x branch

### DIFF
--- a/python/audio2/audiomanager.py
+++ b/python/audio2/audiomanager.py
@@ -3,6 +3,9 @@
 import audio2
 
 INIT_BANK = "Init.bnk"
+AUDIO_STATE_UNINITIALIZED = 0
+AUDIO_STATE_DISABLED = 1
+AUDIO_STATE_ENABLED = 2
 
 
 class AudioManager(object):
@@ -34,7 +37,6 @@ class AudioManager(object):
         self.manager = audio2.GetOrCreateManager()
         self.staticDataRepository = audio2.GetStaticDataRepository()
         self.banksWaitingToLoad = set()
-        self.enabled = False
 
         self.settings = self._CreateAudioSettings(
             baseSoundbankPath, 
@@ -56,7 +58,6 @@ class AudioManager(object):
         """Disable the audio manager and unload all SoundBanks from memory."""
         self.banksWaitingToLoad = set(self.GetLoadedSoundBanks())
         self.manager.Disable()
-        self.enabled = False
 
     def DisableSoundPrioritization(self):
         self.manager.DisableAudioCulling()
@@ -74,7 +75,6 @@ class AudioManager(object):
         """
         self.manager.Enable(self.defaultSoundBanks + soundBanksToLoad + list(self.banksWaitingToLoad))
         audio2.GetListener()
-        self.enabled = True
         self.banksWaitingToLoad = set()
 
     def EnableSoundPrioritization(self):
@@ -91,6 +91,10 @@ class AudioManager(object):
     def GetLoadedSoundBanks(self):
         """Returns the names of all banks loaded into memory."""
         return self.manager.GetLoadedSoundBanks()
+
+    def GetState(self):
+        """Return Carbon Audio's current engine lifecycle state."""
+        return self.manager.GetState()
 
     def GetSoundPrioritizationEnabled(self):
         return self.manager.audioCullingEnabled
@@ -120,7 +124,7 @@ class AudioManager(object):
         self.staticDataRepository.Initialize(audioMetadata)
 
     def LoadSoundBank(self, bankName):
-        if not self.enabled:
+        if self.GetState() != AUDIO_STATE_ENABLED:
             self.banksWaitingToLoad.add(bankName)
         else:    
             self.manager.LoadBank(bankName)
@@ -198,7 +202,7 @@ class AudioManager(object):
         :type banks: list
         :param banks: A list of banks you want to have loaded in addition to the default banks.
         """ 
-        if self.enabled:
+        if self.GetState() == AUDIO_STATE_ENABLED:
             loadedBanks = set(self.GetLoadedSoundBanks())
         else:
             loadedBanks = self.banksWaitingToLoad
@@ -216,7 +220,7 @@ class AudioManager(object):
 
     def UnloadSoundBank(self, bankName):
         if bankName not in self.defaultSoundBanks and bankName != INIT_BANK:
-            if not self.enabled:
+            if self.GetState() != AUDIO_STATE_ENABLED:
                 if bankName in self.banksWaitingToLoad:
                     self.banksWaitingToLoad.remove(bankName)
 

--- a/src/AudEmitter.cpp
+++ b/src/AudEmitter.cpp
@@ -123,7 +123,7 @@ void AudEmitter::GetDebugOptions( Tr2DebugRendererOptions& options )
 
 void AudEmitter::RenderDebugInfo( ITr2DebugRenderer2& renderer )
 {
-	if ( g_audioInitialized )
+	if ( g_audioManager != nullptr && g_audioManager->GetState() == AudioState::Enabled )
 	{
 		if ( !g_debugDisplayAllEmitters )
 		{

--- a/src/AudGameObjResource.cpp
+++ b/src/AudGameObjResource.cpp
@@ -97,7 +97,7 @@ AudGameObjResource::~AudGameObjResource()
 		g_audioManager->UnregisterGameObject( m_ID );
 	}
 
-	if( g_audioInitialized )
+	if( g_audioManager != nullptr && g_audioManager->GetState() != AudioState::Uninitialized )
 	{
 		AK::SoundEngine::CancelEventCallbackGameObject( m_ID );
 		StopAll();
@@ -107,7 +107,7 @@ AudGameObjResource::~AudGameObjResource()
 
 void AudGameObjResource::RegisterWwiseObject()
 {
-	if( g_audioInitialized && m_gameObjRegistered == false )
+	if( g_audioManager != nullptr && g_audioManager->GetState() == AudioState::Enabled && m_gameObjRegistered == false )
 	{
 		AKRESULT result = AK::SoundEngine::RegisterGameObj( m_ID, m_name.c_str() );
 		if( result != AK_Success )
@@ -120,7 +120,7 @@ void AudGameObjResource::RegisterWwiseObject()
 
 void AudGameObjResource::UnregisterWwiseObject()
 {
-	if( g_audioInitialized && m_gameObjRegistered == true )
+	if( g_audioManager != nullptr && g_audioManager->GetState() != AudioState::Uninitialized && m_gameObjRegistered == true )
 	{
 		AKRESULT result = AK::SoundEngine::UnregisterGameObj( m_ID );
 		if( result != AK_Success )
@@ -172,20 +172,9 @@ unsigned int AudGameObjResource::PostEvent( const std::wstring& eventName, bool 
 
 	bool eventIsVital = g_staticDataRepository->EventIsVital( fullEventName );
 	AkPlayingID playingID = AK_INVALID_PLAYING_ID;
-	if ( m_culled || !g_audioEnabled )
+	if ( m_culled || g_audioManager == nullptr || g_audioManager->GetState() != AudioState::Enabled )
 	{
-		for ( auto it = m_eventsOnWake.cbegin(); it != m_eventsOnWake.cend();)
-		{
-			if( g_staticDataRepository->EventIsStopped( *it, fullEventName ) )
-			{
-				it = m_eventsOnWake.erase( it );
-				UpdateEventSoundPrioritizationAttributes();
-			}
-			else
-			{
-				++it;	
-			}
-		}
+		ApplyEventStopRelationships( fullEventName );
 
 		if ( g_staticDataRepository->EventIsLoop( fullEventName ) || eventIsVital )
 		{
@@ -240,6 +229,7 @@ unsigned int AudGameObjResource::PostEvent( const std::wstring& eventName, bool 
 
 			if ( playingID != AK_INVALID_PLAYING_ID )
 			{
+				ApplyEventStopRelationships( fullEventName );
 				m_playingEvents.insert({playingID, fullEventName});
 				eventUsed = true;
 			}
@@ -297,6 +287,7 @@ void AudGameObjResource::PropagateWwiseCallback( AkCallbackType in_eType, AkEven
 void AudGameObjResource::EventFinishedCallback( AkEventCallbackInfo* cbInfo )
 {
 	CcpAutoMutex mutex( m_mutex );
+	m_pendingStoppedPlayingIDs.erase( cbInfo->playingID );
 	m_playingEvents.erase( cbInfo->playingID );
 	UpdateEventSoundPrioritizationAttributes();
 }
@@ -319,23 +310,25 @@ bool AudGameObjResource::StopEvent( const std::wstring& eventName, uint32_t fade
 
 void AudGameObjResource::StopSound( AkPlayingID playingID, uint32_t fadeOutDuration )
 {
-	if ( g_audioInitialized )
+	if ( g_audioManager != nullptr && g_audioManager->GetState() == AudioState::Enabled )
 	{
+		MarkPlayingIDStoppedByRequest( playingID );
 		ExecuteActionOnPlayingID( playingID, ActionTypes::Stop, fadeOutDuration );
 	}
 }
 
 void AudGameObjResource::BreakSound( AkPlayingID playingID, uint32_t fadeOutDuration )
 {
-	if ( g_audioInitialized )
+	if ( g_audioManager != nullptr && g_audioManager->GetState() == AudioState::Enabled )
 	{
+		MarkPlayingIDStoppedByRequest( playingID );
 		ExecuteActionOnPlayingID( playingID, ActionTypes::Break, fadeOutDuration );
 	}
 }
 
 void AudGameObjResource::StopAll()
 {
-	if( g_audioInitialized )
+	if( g_audioManager != nullptr && g_audioManager->GetState() == AudioState::Enabled )
 	{
 		CcpAutoMutex mutex( m_mutex );
 		for ( auto it = begin( m_playingEvents ); it != end( m_playingEvents ); ++it)
@@ -352,7 +345,7 @@ void AudGameObjResource::StopAll()
 //-----------------------------------------------------
 bool AudGameObjResource::SetAttenuationScalingFactor( float value )
 {
-	if( g_audioInitialized )
+	if( g_audioManager != nullptr && g_audioManager->GetState() == AudioState::Enabled )
 	{
 		if( m_gameObjRegistered )
 		{
@@ -375,7 +368,7 @@ int AudGameObjResource::SetPositionHelper( const Vector3& front, const Vector3& 
 {
 	m_position = position;
 
-	if( g_audioInitialized )
+	if( g_audioManager != nullptr && g_audioManager->GetState() == AudioState::Enabled )
 	{
 		if( m_gameObjRegistered )
 		{
@@ -446,51 +439,56 @@ void AudGameObjResource::Initialize( const std::string& name, const std::wstring
 
 bool AudGameObjResource::SetSwitch( const std::wstring& switchGroup, const std::wstring& switchState )
 {
-	if ( g_audioInitialized )
-	{
-		// Store switches sent to it can be used when waking up this game object.
-		m_switchValues[switchGroup] = switchState;
+	// Store switches sent to it can be used when waking up this game object.
+	m_switchValues[switchGroup] = switchState;
 
-		if( m_gameObjRegistered )
+	if( g_audioManager == nullptr || g_audioManager->GetState() != AudioState::Enabled )
+	{
+		return false;
+	}
+
+	if( m_gameObjRegistered )
+	{
+		AKRESULT result = AK::SoundEngine::SetSwitch( switchGroup.c_str(), switchState.c_str(), m_ID );
+		if(result != AK_Success)
 		{
-			AKRESULT result = AK::SoundEngine::SetSwitch( switchGroup.c_str(), switchState.c_str(), m_ID );
-			if(result != AK_Success)
-			{
-				CCP_LOGERR( "Failed to set switch %S %S for game object %d. " 
-							"Received Wwise error code %d", switchGroup.c_str(), switchState.c_str(), m_ID, result );
-				return false;
-			}
-			g_audioManager->LogSetSwitch( m_ID, switchGroup, switchState );
-			return true;
+			CCP_LOGERR( "Failed to set switch %S %S for game object %d. "
+						"Received Wwise error code %d", switchGroup.c_str(), switchState.c_str(), m_ID, result );
+			return false;
 		}
-		else if( !m_culled )
-		{
-			CCP_LOGERR( "SetSwitch was requested on game object %d which was never registered with Wwise.", m_ID );
-		}
+		g_audioManager->LogSetSwitch( m_ID, switchGroup, switchState );
+		return true;
+	}
+	else if( !m_culled )
+	{
+		CCP_LOGERR( "SetSwitch was requested on game object %d which was never registered with Wwise.", m_ID );
 	}
 	return false;
 }
 
 bool AudGameObjResource::SetRTPC( const std::wstring& rtpcName, float rtpcValue )
 {
-	if ( g_audioInitialized )
-	{
-		// Store RTPCs that have been sent so it can be used when waking up this game object.
-		m_rtpcValues[rtpcName] = rtpcValue;
+	// Store RTPCs that have been sent so it can be used when waking up this game object.
+	m_rtpcValues[rtpcName] = rtpcValue;
 
-		if( m_gameObjRegistered )
-		{
-			AKRESULT result = AK::SoundEngine::SetRTPCValue( rtpcName.c_str(), AkRtpcValue(rtpcValue), m_ID );
-			if( result != AK_Success )
-			{
-				CCP_LOGERR( "Failed to set RTPC %S to %f for game object %d. " 
-							"Received Wwise result code %d", rtpcName.c_str(), rtpcValue, m_ID, result );
-				return false;
-			}
-			g_audioManager->LogSetRTPC( m_ID, rtpcName, rtpcValue );
-			return true;
-		}
+	if ( g_audioManager == nullptr || g_audioManager->GetState() != AudioState::Enabled )
+	{
+		return false;
 	}
+
+	if( m_gameObjRegistered )
+	{
+		AKRESULT result = AK::SoundEngine::SetRTPCValue( rtpcName.c_str(), AkRtpcValue(rtpcValue), m_ID );
+		if( result != AK_Success )
+		{
+			CCP_LOGERR( "Failed to set RTPC %S to %f for game object %d. "
+						"Received Wwise result code %d", rtpcName.c_str(), rtpcValue, m_ID, result );
+			return false;
+		}
+		g_audioManager->LogSetRTPC( m_ID, rtpcName, rtpcValue );
+		return true;
+	}
+
 	return false;
 }
 
@@ -504,7 +502,7 @@ bool AudGameObjResource::SetRTPC( const std::wstring& rtpcName, float rtpcValue 
 //-----------------------------------------------------
 bool AudGameObjResource::SeekOnEventPercent( const unsigned int playingID, float percentToSeek )
 {
-	if ( g_audioInitialized )
+	if ( g_audioManager != nullptr && g_audioManager->GetState() == AudioState::Enabled )
 	{
 		CcpAutoMutex mutex( m_mutex );
 		auto it = m_playingEvents.find( playingID );
@@ -531,7 +529,7 @@ bool AudGameObjResource::SeekOnEventPercent( const unsigned int playingID, float
 //-----------------------------------------------------
 bool AudGameObjResource::SeekOnEventMs( const unsigned int playingID, const unsigned int msToSeek)
 {
-	if ( g_audioInitialized )
+	if ( g_audioManager != nullptr && g_audioManager->GetState() == AudioState::Enabled )
 	{
 		CcpAutoMutex mutex( m_mutex );
 		auto it = m_playingEvents.find( playingID );
@@ -571,7 +569,7 @@ std::wstring AudGameObjResource::PrepareEvent( const std::wstring& event, bool b
 //-----------------------------------------------------
 void AudGameObjResource::Wake()
 {
-	if( g_audioEnabled )
+	if( g_audioManager != nullptr && g_audioManager->GetState() == AudioState::Enabled )
 	{
 		if ( m_forceCullingState || m_muted )
 		{
@@ -626,7 +624,7 @@ void AudGameObjResource::Wake()
 //-----------------------------------------------------
 void AudGameObjResource::Cull()
 {
-	if ( g_audioInitialized )
+	if ( g_audioManager != nullptr && g_audioManager->GetState() == AudioState::Enabled )
 	{
 		if ( m_forceCullingState )
 		{
@@ -638,18 +636,23 @@ void AudGameObjResource::Cull()
 		{
 			if ( g_staticDataRepository->EventIsLoop( it->second ) )
 			{
-				StopSound( it->first, 3000 );
-				m_eventsOnWake.insert( it->second );
+				if ( m_pendingStoppedPlayingIDs.find( it->first ) == m_pendingStoppedPlayingIDs.end() )
+				{
+					if ( ExecuteActionOnPlayingID( it->first, ActionTypes::Stop, 3000 ) )
+					{
+						m_eventsOnWake.insert( it->second );
+					}
+				}
 			} 
 			else
 			{
 				if ( m_listenerInRange )
 				{
-					BreakSound( it->first );
+					ExecuteActionOnPlayingID( it->first, ActionTypes::Break );
 				}
 				else
 				{
-					StopSound( it->first );
+					ExecuteActionOnPlayingID( it->first, ActionTypes::Stop );
 				}
 			}
 		}
@@ -738,30 +741,91 @@ void AudGameObjResource::SetDistanceSqFromListener( const float distanceSq )
 //   Helper function to execute actions defined in the ActionTypes enum on a playingID.
 // Arguments:
 //   playingID - The playingID of the sound to execute the action on.
-//   actionType - The action to execute on the sound (e.g. Stop, Break).
+//   action - The action to execute on the sound (e.g. Stop, Break).
 //   fadeOutDuration - If an action supports a fade then this sets the duration of that fade in milliseconds. Defaults to 1000
 //-----------------------------------------------------
-void AudGameObjResource::ExecuteActionOnPlayingID( const AkPlayingID playingID, const ActionTypes action, uint32_t fadeOutDuration )
+bool AudGameObjResource::ExecuteActionOnPlayingID( const AkPlayingID playingID, const ActionTypes action, uint32_t fadeOutDuration )
 {
-	if ( g_audioInitialized )
+	if ( g_audioManager != nullptr && g_audioManager->GetState() == AudioState::Enabled )
 	{
 		CcpAutoMutex mutex( m_mutex );
 		if ( m_playingEvents.find( playingID ) != m_playingEvents.end() )
 		{
+			std::wstring actionName;
 			switch ( action )
 			{
 			case ActionTypes::Stop:
 				AK::SoundEngine::ExecuteActionOnPlayingID( AkActionOnEventType_Stop, playingID, fadeOutDuration );
-				g_audioManager->LogExecuteActionOnPlayingID( m_ID, playingID, L"Stop" );
+				actionName = L"Stop";
 				break;
 			case ActionTypes::Break:
 				AK::SoundEngine::ExecuteActionOnPlayingID( AkActionOnEventType_Break, playingID, fadeOutDuration );
-				g_audioManager->LogExecuteActionOnPlayingID( m_ID, playingID, L"Break" );
+				actionName = L"Break";
 				break;
 			}
+
+			g_audioManager->LogExecuteActionOnPlayingID( m_ID, playingID, actionName );
+			return true;
 		}
 	}
+	return false;
 }
+
+//-----------------------------------------------------
+// Description:
+//   Records that game code explicitly requested a playing sound to stop or break.
+//   Wwise reports completion asynchronously, so the playing ID can remain in
+//   m_playingEvents until the end callback arrives. If audio is disabled before
+//   that callback, Cull() must not mistake the stale loop entry for a paused
+//   loop that should be replayed on Wake().
+// Arguments:
+//   playingID - The playingID that should not be resumed if this object is culled
+//               before Wwise sends its end callback.
+//-----------------------------------------------------
+void AudGameObjResource::MarkPlayingIDStoppedByRequest( AkPlayingID playingID )
+{
+	CcpAutoMutex mutex( m_mutex );
+	auto playingEventIt = m_playingEvents.find( playingID );
+	if ( playingEventIt != m_playingEvents.end() )
+	{
+		m_pendingStoppedPlayingIDs.insert( playingID );
+		m_eventsOnWake.erase( playingEventIt->second );
+		UpdateEventSoundPrioritizationAttributes();
+	}
+}
+
+void AudGameObjResource::ApplyEventStopRelationships( const std::wstring& stoppingEventName )
+{
+	bool updated = false;
+
+	for ( auto it = m_eventsOnWake.cbegin(); it != m_eventsOnWake.cend(); )
+	{
+		if ( g_staticDataRepository->EventIsStopped( *it, stoppingEventName ) )
+		{
+			it = m_eventsOnWake.erase( it );
+			updated = true;
+		}
+		else
+		{
+			++it;
+		}
+	}
+
+	for ( auto it = m_playingEvents.begin(); it != m_playingEvents.end(); ++it )
+	{
+		if ( g_staticDataRepository->EventIsStopped( it->second, stoppingEventName ) )
+		{
+			m_pendingStoppedPlayingIDs.insert( it->first );
+			updated = true;
+		}
+	}
+
+	if ( updated )
+	{
+		UpdateEventSoundPrioritizationAttributes();
+	}
+}
+
 //-----------------------------------------------------
 // Description:
 //	Calculates and updates sound prioritization attributes that are determined by currently playing events or events that will play on wake.

--- a/src/AudGameObjResource.h
+++ b/src/AudGameObjResource.h
@@ -114,7 +114,11 @@ protected:
 	// Propagate any wwise callbacks received for this game object.
 	static void PropagateWwiseCallback( AkCallbackType in_eType, AkEventCallbackInfo* in_pEventInfo, void* in_pCallbackInfo, void* in_pCookie );
 	// Execute the given action on a playing ID if it is playing on this game object.
-	void ExecuteActionOnPlayingID( const AkPlayingID playingID, const ActionTypes action, uint32_t fadeOutDuration = 1000 );
+	bool ExecuteActionOnPlayingID( const AkPlayingID playingID, const ActionTypes action, uint32_t fadeOutDuration = 1000 );
+	// Mark an explicit stop/break request so culling does not treat it as a loop that should resume on wake.
+	void MarkPlayingIDStoppedByRequest( AkPlayingID playingID );
+	// Apply static data relationships for events stopped by the given event.
+	void ApplyEventStopRelationships( const std::wstring& stoppingEventName );
 	// Calculates and updates sound prioritization attributes that are determined by currently playing events or events that will play on wake.
 	void UpdateEventSoundPrioritizationAttributes();
 	// Update the max attenuation radius of this game object if the given event's radius is larger than the current value.
@@ -161,6 +165,8 @@ protected:
 	bool m_hasReceivedPosition;
 	// Events waiting to play on this game object when it wakes up from being culled.
 	std::set<std::wstring> m_eventsOnWake;
+	// Playing IDs that have been explicitly stopped but have not received their Wwise end callback yet.
+	std::set<AkPlayingID> m_pendingStoppedPlayingIDs;
 	// Currently playing events on this game object.
 	std::map<unsigned int, std::wstring> m_playingEvents;
 	// Keeps track of RTPCs sent to this game object.
@@ -170,7 +176,7 @@ protected:
 	// A one shot event sent to this game object while it was culled. 
 	std::pair<std::chrono::steady_clock::time_point, std::wstring> m_waitingOneShotInRange;
 
-	// A mutex to be used when working with m_playingEvents and m_eventsOnWake as they are accessed in different threads.
+	// A mutex to be used when working with m_playingEvents, m_pendingStoppedPlayingIDs and m_eventsOnWake as they are accessed in different threads.
 	CcpMutex m_mutex;
 };
 

--- a/src/AudListener.cpp
+++ b/src/AudListener.cpp
@@ -3,6 +3,7 @@
 #include "stdafx.h"
 #include "AudListener.h"
 
+#include "AudManager.h"
 #include "Vector3.h"
 #include "Utilities.h"
 
@@ -21,7 +22,7 @@ AudListener::~AudListener()
 
 void AudListener::RegisterWwiseObject()
 {
-	if( g_audioInitialized )
+	if( g_audioManager != nullptr && g_audioManager->GetState() == AudioState::Enabled )
 	{
 		if( m_gameObjRegistered == false )
 		{
@@ -32,14 +33,14 @@ void AudListener::RegisterWwiseObject()
 	}
 	else
 	{
-		CCP_LOGERR( "Audio listener was requested to be created before audio was initialized! Audio will be silent because of this. "
-					"Try to change where audio is initialized or create the listener again." );
+		CCP_LOGERR( "Audio listener was requested to be created before audio was enabled! Audio will be silent because of this. "
+					"Try to change where audio is enabled or create the listener again." );
 	}
 }
 
 int AudListener::SetPositionHelper( const Vector3& front, const Vector3& top, const Vector3& position )
 {
-	if( g_audioInitialized )
+	if( g_audioManager != nullptr && g_audioManager->GetState() != AudioState::Uninitialized )
 	{
 		m_position = position;
 		if( m_gameObjRegistered )

--- a/src/AudManager.cpp
+++ b/src/AudManager.cpp
@@ -69,6 +69,9 @@ AudManager::AudManager( IRoot* lockobj ) :
 	m_soundBankMutex( "AudManager", "m_soundBankMutex" ),
 	m_callbackGameObjectsMutex( "AudManager", "m_callbackGameObjectsMutex" ),
 	m_isProfilerCapturing( false ),
+#ifndef AK_OPTIMIZED
+	m_resourceMonitorCallbackRegistered( false ),
+#endif
 	m_audioCullingEnabled( true )
 {
 	// Initialize sound prioritization system
@@ -77,20 +80,31 @@ AudManager::AudManager( IRoot* lockobj ) :
 
 AudManager::~AudManager()
 {
-	// Clean up sound prioritization system
-	delete m_soundPrioritization;
-
-	if( g_audioInitialized )
+	if( GetState() == AudioState::Enabled )
 	{
 		Disable();
 	}
+
+	if( GetState() == AudioState::Disabled )
+	{
+		Terminate();
+	}
+
+	// Clean up sound prioritization system
+	delete m_soundPrioritization;
 }
 
 void AudManager::Process()
 {
-	if( g_audioInitialized )
+	AudioState state = GetState();
+	if( state == AudioState::Uninitialized )
 	{
-		if( m_soundPrioritization->GetAudioCullingEnabled() && g_audioEnabled )
+		return;
+	}
+
+	if( state == AudioState::Enabled )
+	{
+		if( m_soundPrioritization->GetAudioCullingEnabled() )
 		{
 			m_soundPrioritization->CullAudio();
 		}
@@ -98,13 +112,14 @@ void AudManager::Process()
 		// Process bank requests, events, positions, RTPC, etc.
 		AK::SoundEngine::RenderAudio();
 
-		// Update main thread queue
-		g_mainThreadQueue->Update();
+	}
 
-		if( m_log )
-		{
-			m_log->Flush();
-		}
+	// Update main thread queue
+	g_mainThreadQueue->Update();
+
+	if( m_log )
+	{
+		m_log->Flush();
 	}
 }
 
@@ -150,13 +165,19 @@ bool AudManager::Init()
 	WwiseLogServerBridgeInit( AK::Monitor::ErrorLevel_All );
 #endif
 
-	g_audioInitialized = true;
+	SetAudioState( AudioState::Disabled );
 	return true;
 }
 
 void AudManager::Terminate()
 {
 #ifndef AK_OPTIMIZED
+	if( m_resourceMonitorCallbackRegistered && AK::SoundEngine::IsInitialized() )
+	{
+		AK::SoundEngine::UnregisterResourceMonitorCallback( ResourceMonitorCallback );
+		m_resourceMonitorCallbackRegistered = false;
+	}
+
 	AK::Comm::Term();
 #endif
 
@@ -177,7 +198,7 @@ void AudManager::Terminate()
 	// Terminate the Memory Manager
 	AK::MemoryMgr::Term();
 
-	g_audioInitialized = false;
+	SetAudioState( AudioState::Uninitialized );
 }
 
 void AudManager::OnTick( Be::Time realTime, Be::Time simTime, void* cookie )
@@ -372,11 +393,19 @@ bool AudManager::InitSound()
 	}
 
 #ifndef AK_OPTIMIZED
-	AKRESULT result = AK::SoundEngine::RegisterResourceMonitorCallback( ResourceMonitorCallback );
-	if( result != AK_Success )
+	if( !m_resourceMonitorCallbackRegistered )
 	{
-		CCP_LOGERR( "Failed to register resource monitor callback" );
+		AKRESULT result = AK::SoundEngine::RegisterResourceMonitorCallback( ResourceMonitorCallback );
+		if( result != AK_Success )
+		{
+			CCP_LOGERR( "Failed to register resource monitor callback" );
+		}
+		else
+		{
+			m_resourceMonitorCallbackRegistered = true;
+		}
 	}
+
 	CCP_STATS_SET( sampleRate, AK::SoundEngine::GetSampleRate() );
 	CCP_STATS_SET( numSamplesPerFrame, initSettings.uNumSamplesPerFrame );
 #ifndef AK_MAC_OS_X
@@ -389,7 +418,7 @@ bool AudManager::InitSound()
 
 bool AudManager::SetGlobalRTPC( const std::wstring& rtpcName, float value )
 {
-	if( g_audioInitialized && !g_shuttingDown)
+	if( GetState() == AudioState::Enabled && !g_shuttingDown)
 	{
 		AKRESULT result = AK::SoundEngine::SetRTPCValue( rtpcName.c_str(), value );
 		if( result != AK_Success )
@@ -406,7 +435,7 @@ bool AudManager::SetGlobalRTPC( const std::wstring& rtpcName, float value )
 
 bool AudManager::SetState( const std::wstring& stateGroup, const std::wstring& stateName )
 {
-	if( g_audioInitialized && !g_shuttingDown )
+	if( GetState() == AudioState::Enabled && !g_shuttingDown )
 	{
 		// SetState always returns True so no need to check the result.
 		AK::SoundEngine::SetState( stateGroup.c_str(), stateName.c_str() );
@@ -432,7 +461,7 @@ void AudManager::UpdateSettings( AudSettings* settings )
 
 void AudManager::LoadBank( const std::wstring& name )
 {
-	if( g_audioEnabled )
+	if( GetState() == AudioState::Enabled )
 	{
 		AkBankID bankID = ComputeWwiseHashForSoundBank( name );
 		SoundBankStatus soundBankStatus = GetSoundBankStatus( bankID );
@@ -502,7 +531,7 @@ void AudManager::LoadBankCallback( AkUInt32 in_bankID, const void* in_pInMemoryB
 
 void AudManager::UnloadBank( const std::wstring& name )
 {
-	if( g_audioEnabled )
+	if( GetState() == AudioState::Enabled )
 	{
 		AkBankID bankID = ComputeWwiseHashForSoundBank( name );
 		SoundBankStatus soundBankStatus = GetSoundBankStatus( bankID );
@@ -635,7 +664,7 @@ void AudManager::UpdateSoundBankStatus( const AkBankID bankID, const SoundBankSt
 void AudManager::ClearBanks()
 {
 	// Unloads all banks currently loaded in Wwise.
-	if( g_audioInitialized )
+	if( GetState() != AudioState::Uninitialized )
 	{
 		AKRESULT result = AK::SoundEngine::ClearBanks();
 		if( result == AK_Fail )
@@ -652,12 +681,12 @@ void AudManager::ClearBanks()
 
 //-----------------------------------------------------
 // Description:
-//   Disable CarbonAudio which culls all game objects, unloads all SoundBanks, terminates
-//   the sound engine and stops the audio thread.
+//   Disable CarbonAudio which culls all game objects, unloads all SoundBanks,
+//   and stops the audio thread without terminating Wwise.
 //-----------------------------------------------------
 void AudManager::Disable()
 {
-	if( g_audioEnabled == false )
+	if( GetState() != AudioState::Enabled )
 	{
 		return;
 	}
@@ -671,12 +700,8 @@ void AudManager::Disable()
 	}
 
 	ClearBanks();
-#ifndef AK_OPTIMIZED
-	AK::SoundEngine::UnregisterResourceMonitorCallback(ResourceMonitorCallback);
-#endif
 
-	Terminate();
-	g_audioEnabled = false;
+	SetAudioState( AudioState::Disabled );
 	g_shuttingDown = false;
 	BeOS->UnregisterForTicks( this, (void*)"Audio::Tick" );
 }
@@ -697,7 +722,7 @@ bool AudManager::DisableSpatialAudio()
 {
 	const AkOutputDeviceID defaultOutputDeviceId = 0;
 
-	if( !g_audioInitialized )
+	if( GetState() != AudioState::Enabled )
 	{
 		return false;
 	}
@@ -742,17 +767,21 @@ bool AudManager::DisableSpatialAudio()
 //-----------------------------------------------------
 void AudManager::Enable( BankVector soundBanksToLoad )
 {
-	if( g_audioEnabled )
+	if( GetState() == AudioState::Enabled )
 	{
-		return;
-	}
-	if( !Init() )
-	{
-		CCP_LOGERR( "Failed to initialize audio" );
 		return;
 	}
 
-	g_audioEnabled = true;
+	if( GetState() == AudioState::Uninitialized )
+	{
+		if( !Init() )
+		{
+			CCP_LOGERR( "Failed to initialize audio" );
+			return;
+		}
+	}
+
+	SetAudioState( AudioState::Enabled );
 	LoadBank( L"Init.bnk" );
 
 	BankVector::iterator bankEnd = soundBanksToLoad.end();
@@ -785,7 +814,7 @@ void AudManager::Enable( BankVector soundBanksToLoad )
 //-----------------------------------------------------
 bool AudManager::EnableSpatialAudio()
 {
-	if( !g_audioInitialized )
+	if( GetState() != AudioState::Enabled )
 	{
 		return false;
 	}
@@ -890,7 +919,7 @@ const std::wstring AudManager::GetEventName( AkGameObjectID emitterID, AkPlaying
 
 void AudManager::StopAll()
 {
-	if( g_audioInitialized )
+	if( GetState() != AudioState::Uninitialized )
 	{
 		auto objects = m_soundPrioritization->GetPrioritizedAudioObjects();
 		for( auto obj : objects )
@@ -902,7 +931,7 @@ void AudManager::StopAll()
 
 void AudManager::RegisterParameter( const std::wstring& audioParameterName )
 {
-	if( g_audioInitialized )
+	if( GetState() != AudioState::Uninitialized )
 	{
 		CcpAutoMutex lock( m_moniteredParametersMapMutex );
 		m_monitoredParametersMap[audioParameterName].watchers++;
@@ -911,7 +940,7 @@ void AudManager::RegisterParameter( const std::wstring& audioParameterName )
 
 void AudManager::UnregisterParameter( const std::wstring& audioParameterName )
 {
-	if( g_audioInitialized )
+	if( GetState() != AudioState::Uninitialized )
 	{
 		CcpAutoMutex lock( m_moniteredParametersMapMutex );
 		auto it = m_monitoredParametersMap.find( audioParameterName );
@@ -1207,7 +1236,7 @@ void AudManager::AudioDeviceStatusChangeCallback( AK::IAkGlobalPluginContext* in
 
 AKRESULT AudManager::StartProfilerCapture()
 {
-	if( !g_audioEnabled )
+	if( GetState() != AudioState::Enabled )
 	{
 		CCP_LOGERR( "Cannot start profiler capture: Audio is not initialized." );
 		return AK_Fail;
@@ -1248,7 +1277,7 @@ AKRESULT AudManager::StartProfilerCapture()
 
 AKRESULT AudManager::StopProfilerCapture()
 {
-	if( !g_audioEnabled )
+	if( GetState() != AudioState::Enabled )
 	{
 		CCP_LOGERR( "Cannot stop profiler capture: Audio is not initialized." );
 		return AK_Fail;

--- a/src/AudManager.cpp
+++ b/src/AudManager.cpp
@@ -21,6 +21,7 @@
 #include <AK/Plugin/AkVorbisDecoderFactory.h>
 #include <AK/Plugin/MasteringSuiteFXFactory.h>
 #include <AK/Plugin/Ak3DAudioBedMixerFXFactory.h>
+#include <AK/Plugin/AkSidechainFXFactory.h>
 
 #include "tbb/parallel_for.h"
 

--- a/src/AudManager.cpp
+++ b/src/AudManager.cpp
@@ -500,7 +500,7 @@ void AudManager::SetSpatialAudioGeometryEnabled( bool enabled )
 		return;
 	}
 
-	if( !g_audioInitialized )
+	if( GetState() != AudioState::Enabled )
 	{
 		m_spatialAudioSettings->SetSpatialAudioGeometryEnabled( enabled );
 		return;

--- a/src/AudManager.h
+++ b/src/AudManager.h
@@ -29,6 +29,13 @@ enum class SoundBankStatus
 	NOT_LOADED
 };
 
+enum class AudioState
+{
+	Uninitialized,
+	Disabled,
+	Enabled
+};
+
 struct SoundBankInfo
 {
 	SoundBankStatus soundBankStatus;
@@ -66,7 +73,7 @@ public:
 
 	// Unloads all soundbanks currently loaded.
 	void ClearBanks();
-	// Disable CarbonAudio and terminate all relevant subprocesses.
+	// Disable CarbonAudio without terminating Wwise.
 	void Disable();
 	// Disable spatial audio. Works whether or not the user has a spatial audio endpoint active on their system.
 	bool DisableSpatialAudio();
@@ -80,6 +87,10 @@ public:
 	AudListenerPtr GetListener();
 	// Retreive a vector of all currently loaded soundbanks.
 	const std::vector<std::wstring> GetLoadedSoundBanks();
+	// Return Carbon Audio's current engine lifecycle state.
+	AudioState GetState() const { return m_state.load( std::memory_order_acquire ); }
+	// Return the lifecycle state as an integer for scripting layers.
+	int GetStateValue() const { return static_cast<int>( GetState() ); }
 	// Get the name of a SoundBank given its bank ID
 	std::wstring GetSoundBankName( const AkBankID bankID );
 	// Get info about currently loaded, loading or unloading SoundBanks.
@@ -179,6 +190,8 @@ private:
 	void Process();
 	// Registers audio2 for the tick handler.
 	void RegisterForTicks();
+	// Update Carbon Audio's lifecycle state.
+	void SetAudioState( AudioState state ) { m_state.store( state, std::memory_order_release ); }
 	// Terminates all Wwise modules.
 	void Terminate();
 	// Update all watched audio parameters with their current values in Wwise (if they exist).
@@ -224,10 +237,14 @@ private:
 	// A boolean for the state of the profiler capture
 	bool m_isProfilerCapturing;
 
+	std::atomic<AudioState> m_state{ AudioState::Uninitialized };
+
 #ifndef AK_OPTIMIZED
 	// Wwise communication interface settings.
 	AkCommSettings m_commSettings;
-    // Defines the Wwise resource monitor callback function
+	// Tracks resource monitor callback registration across disable/enable.
+	bool m_resourceMonitorCallbackRegistered;
+	// Defines the Wwise resource monitor callback function
 	static void ResourceMonitorCallback( const AkResourceMonitorDataSummary* in_pdataSummary );
 #endif
 	//Debug

--- a/src/AudManager_Blue.cpp
+++ b/src/AudManager_Blue.cpp
@@ -5,7 +5,15 @@
 
 #include "AudGameObjResource.h"
 
+const Be::VarChooser AudioStateChooser[] = {
+	{ "Uninitialized", static_cast<int>(AudioState::Uninitialized) },
+	{ "Disabled", static_cast<int>(AudioState::Disabled) },
+	{ "Enabled", static_cast<int>(AudioState::Enabled) },
+	{ nullptr, 0 }
+};
+
 BLUE_DEFINE( AudManager );
+BLUE_REGISTER_ENUM( "AUDIO_STATE", AudioState, AudioStateChooser );
 
 const Be::ClassInfo* AudManager::ExposeToBlue()
 {
@@ -36,7 +44,7 @@ const Be::ClassInfo* AudManager::ExposeToBlue()
 		( 
 			"Disable",
 			Disable,
-			"Disable CarbonAudio which unloads all SoundBanks and terminates the sound engine."
+			"Disable CarbonAudio which unloads all SoundBanks without terminating Wwise."
 		)
 		MAP_METHOD_AND_WRAP
 		( 
@@ -87,6 +95,12 @@ const Be::ClassInfo* AudManager::ExposeToBlue()
 			"GetLoadedSoundBanks",
 			GetLoadedSoundBanks,
 			"Return a list of loaded soundbanks."
+		)
+		MAP_METHOD_AND_WRAP
+		(
+			"GetState",
+			GetStateValue,
+			"Return Carbon Audio's current engine lifecycle state."
 		)
 		MAP_METHOD_AND_WRAP
 		( 

--- a/src/AudParameter.cpp
+++ b/src/AudParameter.cpp
@@ -18,7 +18,7 @@ bool AudParameter::OnModified( Be::Var* value )
 {
 	if ( ( Be::Var* )&m_value == value )
 	{
-		if( g_audioInitialized && m_ID )
+		if( g_audioManager != nullptr && g_audioManager->GetState() == AudioState::Enabled && m_ID )
 		{
 			AK::SoundEngine::SetRTPCValue( m_name.c_str(), m_value, m_ID );
 			g_audioManager->LogSetRTPC( m_ID, m_name, m_value );

--- a/src/AudUIPlayer.cpp
+++ b/src/AudUIPlayer.cpp
@@ -3,6 +3,8 @@
 #include <stdafx.h>
 #include "AudUIPlayer.h"
 
+#include "AudManager.h"
+
 
 AudUIPlayer::AudUIPlayer( IRoot* lockobj ) : AudEmitter( UI_GAME_OBJ_ID, lockobj )
 {
@@ -25,7 +27,7 @@ AudUIPlayer::~AudUIPlayer()
 // ----------------------------------------------------------------------------------------
 unsigned int AudUIPlayer::SendEventWithCallback( const std::wstring& name )
 {
-	if( g_audioEnabled )
+	if( g_audioManager != nullptr && g_audioManager->GetState() == AudioState::Enabled )
 	{
 		m_callbackEventName = PrepareEvent(name, false);
 		if(m_callback)
@@ -51,7 +53,7 @@ unsigned int AudUIPlayer::SendEventWithCallback( const std::wstring& name )
 // ----------------------------------------------------------------------------------------
 unsigned int AudUIPlayer::PostDialogueEvent( const std::wstring& eventName )
 {
-	if( g_audioEnabled )
+	if( g_audioManager != nullptr && g_audioManager->GetState() == AudioState::Enabled )
 	{
 		return PostEvent( eventName.c_str(), false, 0);
 	}
@@ -68,7 +70,7 @@ unsigned int AudUIPlayer::PostDialogueEvent( const std::wstring& eventName )
 //-----------------------------------------------------
 int32_t AudUIPlayer::GetEventPlayPosition( const unsigned int playingID )
 {
-	if ( g_audioInitialized )
+	if ( g_audioManager != nullptr && g_audioManager->GetState() == AudioState::Enabled )
 	{
 		AkTimeMs time = 0;
 		AKRESULT result = AK::SoundEngine::GetSourcePlayPosition( playingID, &time ); 
@@ -78,7 +80,7 @@ int32_t AudUIPlayer::GetEventPlayPosition( const unsigned int playingID )
 		}
 		return time;
 	}
-	return 0;
+	return -1;
 }
 
 //-----------------------------------------------------

--- a/src/Audio2.h
+++ b/src/Audio2.h
@@ -23,9 +23,7 @@ const int START_GAME_OBJ_COUNT = 5;
 // Game objects are culled by default so this value will never hit Wwise.
 const Vector3 WWISE_INIT_POSITION = Vector3(FLT_MAX, FLT_MAX, FLT_MAX);
 
-extern bool g_audioEnabled;
 extern bool g_shuttingDown;
-extern bool g_audioInitialized;
 extern bool g_debugDisplayAllEmitters;
 extern bool g_wwiseCommunicationEnabled;
 extern const std::string g_wwiseVersion;

--- a/src/AudioCurveSetDriver.cpp
+++ b/src/AudioCurveSetDriver.cpp
@@ -18,7 +18,10 @@ AudioCurveSetDriver::AudioCurveSetDriver( IRoot* lockobj ) :
 
 AudioCurveSetDriver::~AudioCurveSetDriver()
 {
-	g_audioManager->UnregisterParameter(m_audioParameterName);
+	if( g_audioManager != nullptr && m_audioParameterName != L"" )
+	{
+		g_audioManager->UnregisterParameter( m_audioParameterName );
+	}
 }
 
 bool AudioCurveSetDriver::Initialize()

--- a/src/AudioCurveSetDriver.cpp
+++ b/src/AudioCurveSetDriver.cpp
@@ -53,7 +53,7 @@ double AudioCurveSetDriver::GetCurveSetTime( double time )
 
 bool AudioCurveSetDriver::IsValid() const
 {
-	return g_audioEnabled && m_audioParameterName != L"" && m_audioParameterExists;
+	return g_audioManager != nullptr && g_audioManager->GetState() == AudioState::Enabled && m_audioParameterName != L"" && m_audioParameterExists;
 }
 
 const std::wstring& AudioCurveSetDriver::GetAudioParameterName()

--- a/src/AudioInputMgr.cpp
+++ b/src/AudioInputMgr.cpp
@@ -6,6 +6,7 @@
 
 #include "AudioInputMgr.h"
 #include "Audio2.h"
+#include "AudManager.h"
 
 std::map<int, AudioInputMgr*> g_audioInputMgrMap;
 CcpMutex g_inputMgrMapMutex( "AudioInputMgr", "g_inputMgrMapMutex" );
@@ -33,7 +34,7 @@ AudioInputMgr::~AudioInputMgr()
 // Start the Wwise Audio Input plugin and set callbacks Wwise will call.
 void AudioInputMgr::StartInput( uint32_t channels, uint32_t bps, uint32_t rate )
 {
-	if( !g_audioInitialized )
+	if( g_audioManager == nullptr || g_audioManager->GetState() != AudioState::Enabled )
 	{
 		return;
 	}
@@ -59,25 +60,29 @@ void AudioInputMgr::StartInput( uint32_t channels, uint32_t bps, uint32_t rate )
 // Stop the audio input plugin which will stop Wwise callbacks.
 void AudioInputMgr::StopInput()
 {
-	if( !g_audioInitialized )
+	if( m_playingID == 0 )
 	{
 		return;
 	}
-	if ( m_playingID > 0 )
+
+	AkPlayingID playingID = m_playingID;
+	m_playingID = 0;
+
+	{
+		CcpAutoMutex lock( g_inputMgrMapMutex );
+		g_audioInputMgrMap.erase( playingID );
+	}
+
+	if( g_audioManager != nullptr && g_audioManager->GetState() == AudioState::Enabled )
 	{
 		// Stopping the event called in StartInput will kill the Audio Input plugin in Wwise.
-		AK::SoundEngine::StopPlayingID( m_playingID );
-
-		CcpAutoMutex lock( g_inputMgrMapMutex );
-		g_audioInputMgrMap.erase( m_playingID );
-
-		m_playingID = 0;
+		AK::SoundEngine::StopPlayingID( playingID );
 	}
 }
 
 void AudioInputMgr::SetVolume( float volume )
 {
-	if( !g_audioInitialized || m_playingID == 0 )
+	if( g_audioManager == nullptr || g_audioManager->GetState() != AudioState::Enabled || m_playingID == 0 )
 	{
 		return;
 	}

--- a/src/Components/StretchAudio.cpp
+++ b/src/Components/StretchAudio.cpp
@@ -43,7 +43,7 @@ bool StretchAudio::Initialize()
 
 void StretchAudio::Update( Vector3& sourcePosition, Vector3& destPosition )
 {
-	if ( !g_audioEnabled )
+	if ( g_audioManager == nullptr || g_audioManager->GetState() != AudioState::Enabled )
 	{
 		return;
 	}

--- a/src/audio2.cpp
+++ b/src/audio2.cpp
@@ -26,8 +26,6 @@ HINSTANCE gInstance = NULL;
 AudManager* g_audioManager = nullptr;
 AudStaticDataRepository* g_staticDataRepository = nullptr;
 
-bool g_audioEnabled = false;
-bool g_audioInitialized = false;
 bool g_shuttingDown = false;
 bool g_debugDisplayAllEmitters = false;
 bool g_wwiseCommunicationEnabled = false;

--- a/tests/python/audiotests/test/test_audmanager_exposure.py
+++ b/tests/python/audiotests/test/test_audmanager_exposure.py
@@ -186,9 +186,3 @@ class TestAudManagerExposure(unittest.TestCase):
         self.audioManager.EnableDebugDisplayAllEmitters()
         self.assertTrue(self.audioManager.GetDebugDisplayAllEmitters())
 
-    def test_audmanager_disabling_clears_banks(self):
-        """Test that disabling AudManager clears all soundbanks."""
-        from audio2.audiomanager import INIT_BANK
-        self.audioManager.LoadBank(INIT_BANK)
-        self.audioManager.Disable()
-        self.assertEqual(self.audioManager.GetLoadedSoundBanks(), [])

--- a/tests/python/audiotests/test/test_auduiplayer_exposure.py
+++ b/tests/python/audiotests/test/test_auduiplayer_exposure.py
@@ -66,3 +66,15 @@ class TestAudUIPlayerExposure(BaseAudio2TestClass):
         # Test invalid playingID with GetEventPlayPosition
         invalidPlayPosition = uiPlayer.GetEventPlayPosition(999999)
         self.assertEqual(invalidPlayPosition, -1)
+
+    def test_auduiplayer_geteventplayposition_returns_invalid_when_disabled(self):
+        import audio2
+        uiPlayer = audio2.GetUIPlayer()
+        uiPlayer.SetPosition((0,0,0), (0,0,0), (0,0,0))
+        PumpOSWithTimeout(self.alwaysTrueBoolean, maxTries=3)
+        playingID = uiPlayer.PostDialogueEvent(ONE_SHOT_EVENT)
+        self.assertTrue(playingID > 0)
+
+        self.audioManager.Disable()
+
+        self.assertEqual(uiPlayer.GetEventPlayPosition(playingID), -1)

--- a/tests/python/audiotests/test/test_python_audiomanager.py
+++ b/tests/python/audiotests/test/test_python_audiomanager.py
@@ -5,7 +5,6 @@ import unittest
 from audiotests.base_test_class import COMMON_BNK, LOOP_BNK, LOOP_EVENT, ONE_SHOT_BNK, ONE_SHOT_EVENT, SOUNDBANK_FILEPATH
 from audiotests.base_test_class import BaseAudio2TestClass
 from audiotests.utils import GetAudioMetadataFromFile, PumpOSWithTimeout
-from audio2.audiomanager import AUDIO_STATE_DISABLED, AUDIO_STATE_ENABLED
 
 class TestPythonAudioManager(BaseAudio2TestClass):
     @classmethod
@@ -43,6 +42,7 @@ class TestPythonAudioManager(BaseAudio2TestClass):
         self.assertEqual(self.audioManager.GetLoadedSoundBanks(), [INIT_BANK])
 
     def test_disable_clears_banks(self):
+        from audio2.audiomanager import AUDIO_STATE_DISABLED
         self.audioManager.LoadSoundBanks([COMMON_BNK, LOOP_BNK])
         self.pumpUntil(lambda: self.expectedSoundBanksAreLoaded([COMMON_BNK, LOOP_BNK]))
         self.assertTrue(set([COMMON_BNK, LOOP_BNK]).issubset(set(self.audioManager.GetLoadedSoundBanks())))
@@ -53,7 +53,7 @@ class TestPythonAudioManager(BaseAudio2TestClass):
         self.assertEqual(self.audioManager.GetState(), AUDIO_STATE_DISABLED)
 
     def test_disable_then_enable_can_load_bank_and_play_event(self):
-        from audio2.audiomanager import INIT_BANK
+        from audio2.audiomanager import INIT_BANK, AUDIO_STATE_DISABLED, AUDIO_STATE_ENABLED
         import audio2
 
         self.audioManager.Disable()
@@ -125,6 +125,7 @@ class TestPythonAudioManager(BaseAudio2TestClass):
         self.assertNotIn(LOOP_EVENT, emitter.GetPlayingEvents().values())
 
     def test_engine_state_transitions_across_disable_enable(self):
+        from audio2.audiomanager import AUDIO_STATE_DISABLED, AUDIO_STATE_ENABLED
         self.audioManager.Disable()
         self.assertEqual(self.audioManager.GetState(), AUDIO_STATE_DISABLED)
 

--- a/tests/python/audiotests/test/test_python_audiomanager.py
+++ b/tests/python/audiotests/test/test_python_audiomanager.py
@@ -2,9 +2,10 @@
 
 import unittest
 
-from audiotests.base_test_class import COMMON_BNK, LOOP_BNK, ONE_SHOT_BNK, SOUNDBANK_FILEPATH
+from audiotests.base_test_class import COMMON_BNK, LOOP_BNK, LOOP_EVENT, ONE_SHOT_BNK, ONE_SHOT_EVENT, SOUNDBANK_FILEPATH
 from audiotests.base_test_class import BaseAudio2TestClass
-from audiotests.utils import PumpOSWithTimeout
+from audiotests.utils import GetAudioMetadataFromFile, PumpOSWithTimeout
+from audio2.audiomanager import AUDIO_STATE_DISABLED, AUDIO_STATE_ENABLED
 
 class TestPythonAudioManager(BaseAudio2TestClass):
     @classmethod
@@ -15,12 +16,24 @@ class TestPythonAudioManager(BaseAudio2TestClass):
     def loadedSoundBanksAreEmpty(self):
         return self.audioManager.GetLoadedSoundBanks() == []
 
+    def pumpUntil(self, conditionFunc, maxTries=10):
+        self.assertTrue(
+            PumpOSWithTimeout(lambda: not conditionFunc(), maxTries=maxTries),
+            "Timed out waiting for audio test condition."
+        )
+
+    def expectedSoundBanksAreLoaded(self, expectedSoundBanks):
+        return set(expectedSoundBanks).issubset(set(self.audioManager.GetLoadedSoundBanks()))
+
     def setUp(self):
         self.Initialize(defaultSoundBanks=[]) # Reset the default soundbanks
         self.audioManager.UnloadSoundBanks([COMMON_BNK, ONE_SHOT_BNK, LOOP_BNK])
         self.audioManager.Enable()
 
-        PumpOSWithTimeout(self.loadedSoundBanksAreEmpty)
+        self.assertTrue(
+            PumpOSWithTimeout(self.loadedSoundBanksAreEmpty),
+            "Timed out waiting for the init soundbank to load."
+        )
 
     def tearDown(self):
         self.audioManager.Disable()
@@ -28,6 +41,95 @@ class TestPythonAudioManager(BaseAudio2TestClass):
     def test_init_soundbank_is_loaded_when_enabled(self):
         from audio2.audiomanager import INIT_BANK
         self.assertEqual(self.audioManager.GetLoadedSoundBanks(), [INIT_BANK])
+
+    def test_disable_clears_banks(self):
+        self.audioManager.LoadSoundBanks([COMMON_BNK, LOOP_BNK])
+        self.pumpUntil(lambda: self.expectedSoundBanksAreLoaded([COMMON_BNK, LOOP_BNK]))
+        self.assertTrue(set([COMMON_BNK, LOOP_BNK]).issubset(set(self.audioManager.GetLoadedSoundBanks())))
+
+        self.audioManager.Disable()
+
+        self.assertEqual(self.audioManager.GetLoadedSoundBanks(), [])
+        self.assertEqual(self.audioManager.GetState(), AUDIO_STATE_DISABLED)
+
+    def test_disable_then_enable_can_load_bank_and_play_event(self):
+        from audio2.audiomanager import INIT_BANK
+        import audio2
+
+        self.audioManager.Disable()
+        self.assertEqual(self.audioManager.GetState(), AUDIO_STATE_DISABLED)
+
+        self.audioManager.Enable([COMMON_BNK, LOOP_BNK])
+        self.assertEqual(self.audioManager.GetState(), AUDIO_STATE_ENABLED)
+        self.pumpUntil(lambda: self.expectedSoundBanksAreLoaded([COMMON_BNK, LOOP_BNK]))
+
+        self.assertEqual(set(self.audioManager.GetLoadedSoundBanks()), set([INIT_BANK, COMMON_BNK, LOOP_BNK]))
+        emitter = audio2.AudEmitter("lifecycleEmitter")
+        emitter.SetPosition((0,0,0), (0,0,0), (0,0,0))
+        listener = audio2.GetListener()
+        listener.SetPosition((0,0,0), (0,0,0), (0,0,0))
+        PumpOSWithTimeout(self.alwaysTrueBoolean, maxTries=3)
+        playingID = emitter.SendEvent(LOOP_EVENT)
+        self.assertTrue(playingID > 0)
+        emitter.StopAll()
+
+    def test_stopped_loop_does_not_resume_after_disable_enable(self):
+        import audio2
+
+        self.audioManager.LoadSoundBanks([COMMON_BNK, LOOP_BNK])
+        self.pumpUntil(lambda: self.expectedSoundBanksAreLoaded([COMMON_BNK, LOOP_BNK]))
+
+        emitter = audio2.AudEmitter("stoppedLoopLifecycleEmitter")
+        emitter.SetPosition((0,0,0), (0,0,0), (0,0,0))
+        listener = audio2.GetListener()
+        listener.SetPosition((0,0,0), (0,0,0), (0,0,0))
+        PumpOSWithTimeout(self.alwaysTrueBoolean, maxTries=3)
+
+        playingID = emitter.SendEvent(LOOP_EVENT)
+        self.assertTrue(playingID > 0)
+        self.assertEqual(list(emitter.GetPlayingEvents().values()), [LOOP_EVENT])
+
+        self.assertTrue(emitter.StopEvent(LOOP_EVENT, 1000))
+        self.audioManager.Disable()
+        self.audioManager.Enable()
+        self.pumpUntil(lambda: emitter.GetPlayingEvents() == {})
+
+        self.assertEqual(emitter.GetPlayingEvents(), {})
+
+    def test_loop_stopped_by_posted_event_does_not_resume_after_disable_enable(self):
+        import audio2
+
+        audioMetadata = GetAudioMetadataFromFile()
+        audioMetadata["Events"][LOOP_EVENT]["eventsStoppedBy"] = [ONE_SHOT_EVENT]
+        self.audioManager.Disable()
+        self.audioManager.Initialize(audioMetadata, defaultSoundBanks=[])
+        self.audioManager.Enable([COMMON_BNK, LOOP_BNK, ONE_SHOT_BNK])
+        self.pumpUntil(lambda: self.expectedSoundBanksAreLoaded([COMMON_BNK, LOOP_BNK, ONE_SHOT_BNK]))
+
+        emitter = audio2.AudEmitter("postedStopLifecycleEmitter")
+        emitter.SetPosition((0,0,0), (0,0,0), (0,0,0))
+        listener = audio2.GetListener()
+        listener.SetPosition((0,0,0), (0,0,0), (0,0,0))
+        PumpOSWithTimeout(self.alwaysTrueBoolean, maxTries=3)
+
+        loopPlayingID = emitter.SendEvent(LOOP_EVENT)
+        self.assertTrue(loopPlayingID > 0)
+        self.assertEqual(list(emitter.GetPlayingEvents().values()), [LOOP_EVENT])
+
+        stopPlayingID = emitter.SendEvent(ONE_SHOT_EVENT)
+        self.assertTrue(stopPlayingID > 0)
+        self.audioManager.Disable()
+        self.audioManager.Enable()
+        self.pumpUntil(lambda: LOOP_EVENT not in emitter.GetPlayingEvents().values())
+
+        self.assertNotIn(LOOP_EVENT, emitter.GetPlayingEvents().values())
+
+    def test_engine_state_transitions_across_disable_enable(self):
+        self.audioManager.Disable()
+        self.assertEqual(self.audioManager.GetState(), AUDIO_STATE_DISABLED)
+
+        self.audioManager.Enable()
+        self.assertEqual(self.audioManager.GetState(), AUDIO_STATE_ENABLED)
 
     def test_unload_soundbank_doesnt_remove_init_bank(self):
         from audio2.audiomanager import INIT_BANK
@@ -39,7 +141,10 @@ class TestPythonAudioManager(BaseAudio2TestClass):
         self.audioManager.Disable()
         self.Initialize(defaultSoundBanks=[ONE_SHOT_BNK])
         self.audioManager.Enable()
-        PumpOSWithTimeout(self.loadedSoundBanksAreEmpty)
+        self.assertTrue(
+            PumpOSWithTimeout(self.loadedSoundBanksAreEmpty),
+            "Timed out waiting for the init soundbank to load."
+        )
         self.audioManager.UnloadSoundBank(ONE_SHOT_BNK)
         self.assertEqual(set(self.audioManager.GetLoadedSoundBanks()),set([INIT_BANK, ONE_SHOT_BNK]))
 

--- a/tests/python/audiotests/test/test_spatial_audio_exposure.py
+++ b/tests/python/audiotests/test/test_spatial_audio_exposure.py
@@ -6,7 +6,6 @@ from audiotests.base_test_class import SOUNDBANK_FILEPATH
 from audiotests.base_test_class import BaseAudio2TestClass
 from audiotests.base_test_class import GetAudioMetadataFromFile
 from audiotests.utils import PumpOSWithTimeout
-from audio2.audiomanager import AUDIO_STATE_DISABLED
 
 class TestSpatialAudio(BaseAudio2TestClass):
     """Test spatial audio related features."""
@@ -114,6 +113,7 @@ class TestSpatialAudio(BaseAudio2TestClass):
         PumpOSWithTimeout(self.alwaysTrueBoolean, maxTries=3)
 
     def test_spatial_audio_endpoints_dont_crash_when_audio_not_enabled(self):
+        from audio2.audiomanager import AUDIO_STATE_DISABLED
         self.Initialize()
         self.audioManager.Enable()
         self.audioManager.Disable()

--- a/tests/python/audiotests/test/test_spatial_audio_exposure.py
+++ b/tests/python/audiotests/test/test_spatial_audio_exposure.py
@@ -6,6 +6,7 @@ from audiotests.base_test_class import SOUNDBANK_FILEPATH
 from audiotests.base_test_class import BaseAudio2TestClass
 from audiotests.base_test_class import GetAudioMetadataFromFile
 from audiotests.utils import PumpOSWithTimeout
+from audio2.audiomanager import AUDIO_STATE_DISABLED
 
 class TestSpatialAudio(BaseAudio2TestClass):
     """Test spatial audio related features."""
@@ -113,13 +114,12 @@ class TestSpatialAudio(BaseAudio2TestClass):
         PumpOSWithTimeout(self.alwaysTrueBoolean, maxTries=3)
 
     def test_spatial_audio_endpoints_dont_crash_when_audio_not_enabled(self):
-        if not self.audioManager.SpatialAudioIsSupported(): 
-            print("Skipping this test because Carbon Audio does not support spatial audio on this platform...")
-            return
-
+        self.Initialize()
+        self.audioManager.Enable()
         self.audioManager.Disable()
         PumpOSWithTimeout(self.alwaysTrueBoolean, maxTries=3)
 
+        self.assertEqual(self.audioManager.GetState(), AUDIO_STATE_DISABLED)
         self.assertFalse(self.audioManager.DisableSpatialAudio())
         self.assertFalse(self.audioManager.EnableSpatialAudio())
 

--- a/tests/python/audiotests/utils.py
+++ b/tests/python/audiotests/utils.py
@@ -7,10 +7,13 @@ import os
 AUDIO_METADATA_FILEPATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "test", "soundbanks", "SoundPrioritizationMetadata.json"))
 def PumpOSWithTimeout(booleanFunc, maxTries=10):
     numTries = 0
-    while( numTries < maxTries and booleanFunc() ):
+    while( numTries < maxTries ):
+        if not booleanFunc():
+            return True
         blue.pyos.synchro.SleepWallclock(100)
         blue.os.Pump()
         numTries += 1
+    return not booleanFunc()
 
 def GetAudioMetadataFromFile():
     """Gets audio metadata from file and returns it as a dict. Also converts eventIDs to int in the process."""


### PR DESCRIPTION
Cherry-picks 3 commits from release/7.x that haven't landed on main yet each as its own commit. These have all been battle tested in Frontier since it's cycle 6 update. 

* Keep Wwise alive when audio is disabled (#96): Fixes a crash from rapidly disabling/re-enabling audio (introduced by the Wwise 2025 upgrade), by keeping the Wwise engine initialized while disabled instead of fully terminating it, and preserving state to restore RTPCs/switches/banks/loops on re-enable.
* Include Wwise sidechain plugin (#97)
* Fix crash in AudioCurveSetDriver when not initialized (#98)