### PR TITLE
Build against latest version of core and blue

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -27,6 +27,10 @@
       "name": "carbon-exefile",
       "version>=": "4.1.1",
       "host": true
+    },
+    {
+      "name": "carbon-core",
+      "version>=": "3.0.1"
     }
   ],
   "overrides": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "dependencies": [
     {
       "name": "carbon-blue",
-      "version>=": "5.1.2"
+      "version>=": "6.0.0"
     },
     {
       "name": "carbon-math",


### PR DESCRIPTION
An ABI breaking change was introduced in carbon-blue recently, requiring downstream components to opt into this new version of blue.