### PR TITLE
Line-of-Sight audio Occlusion and Obstruction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,14 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
             RUNTIME DESTINATION bin/${CCP_PLATFORM}/${CCP_ARCHITECTURE}/${CCP_TOOLSET}
         )
 
+       if(MSVC)
+            install(
+                FILES $<TARGET_PDB_FILE:CarbonAudio>
+                CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES}
+                DESTINATION bin/${CCP_PLATFORM}/${CCP_ARCHITECTURE}/${CCP_TOOLSET}
+                OPTIONAL
+            )
+        endif()
         # Generate target configuration for the monolith
         configure_ccp_vendor_config_file(
             TARGET CarbonAudio

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ ccp_add_library(CarbonAudio SHARED
 	src/AudGameObjResource.cpp
 	src/AudGeometry.cpp
 	src/AudGeometry_Blue.cpp
+    src/AudObstructionOcclusion.cpp
 	src/SpatialAudioSettings.cpp
 	src/audio2.cpp
 	src/AudGameObjResource_Blue.cpp
@@ -83,6 +84,7 @@ target_sources(CarbonAudio PRIVATE
 	src/AudUIPlayer.h
 	src/AudMusicPlayer.h
 	src/AudGeometry.h
+    src/AudObstructionOcclusion.h
 	src/SpatialAudioSettings.h
 	src/autoversion.h
 	src/DebugUtilities.h

--- a/InstallToMonolith.vcxproj
+++ b/InstallToMonolith.vcxproj
@@ -23,7 +23,7 @@
     <MonolithBranchRoot>$(CCP_EVE_PERFORCE_BRANCH_PATH)</MonolithBranchRoot>
     <MonolithBranchRoot Condition="'$(MonolithBranchRoot)' == ''">$([MSBuild]::GetRegistryValue('HKEY_CURRENT_USER\Environment', 'CCP_EVE_PERFORCE_BRANCH_PATH'))</MonolithBranchRoot>
     <MonolithInstallPrefix Condition="'$(MonolithBranchRoot)' != ''">$(MonolithBranchRoot.Replace('\', '/'))/vendor/github.com/ccpgames/carbon-audio/develop</MonolithInstallPrefix>
-    <MonolithInstallDirWin Condition="'$(MonolithBranchRoot)' != ''">$(MonolithBranchRoot)\vendor\github.com\ccpgames\carbon-audio\develop</MonolithInstallDirWin>
+    <MonolithInstallDirWin Condition="'$(MonolithBranchRoot)' != ''">$(MonolithBranchRoot)\vendor\github.com\carbonengine\audio\develop</MonolithInstallDirWin>
     <MonolithBuildDir>.cmake-build-monolith</MonolithBuildDir>
     <RepoRoot>$(ProjectDir.Replace('\', '/'))</RepoRoot>
     <MonolithBuildScript>setlocal
@@ -35,7 +35,6 @@ set "PATH_TO_VCPKG_ROOT=$(ProjectDir)vendor\github.com\microsoft\vcpkg"
 echo Installing CarbonAudio to: $(MonolithInstallPrefix)
 cmake -S . -B $(MonolithBuildDir) -G "Visual Studio 18 2026" "-DCMAKE_TOOLCHAIN_FILE=$(RepoRoot)vendor/github.com/microsoft/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=$(RepoRoot)vendor/github.com/carbonengine/vcpkg-registry/toolchains/x64-windows-145-carbon.cmake" "-DVCPKG_OVERLAY_TRIPLETS=$(RepoRoot)vendor/github.com/carbonengine/vcpkg-registry/triplets" -DVCPKG_TARGET_TRIPLET=x64-windows-internal -DVCPKG_HOST_TRIPLET=x64-windows-internal -DVCPKG_USE_HOST_TOOLS=ON -DINSTALL_TO_MONOLITH=ON -DBUILD_TESTING=OFF "-DCMAKE_INSTALL_PREFIX=$(MonolithInstallPrefix)"
 if errorlevel 1 exit /b 1
-rem Wipe any existing install so this build fully replaces it (cmake install never removes stale files).
 if exist "$(MonolithInstallDirWin)" echo Removing existing install at: $(MonolithInstallDirWin)
 if exist "$(MonolithInstallDirWin)" rmdir /s /q "$(MonolithInstallDirWin)"
 cmake --build $(MonolithBuildDir) --config Internal --target INSTALL

--- a/InstallToMonolith.vcxproj
+++ b/InstallToMonolith.vcxproj
@@ -22,9 +22,10 @@
   <PropertyGroup>
     <MonolithBranchRoot>$(CCP_EVE_PERFORCE_BRANCH_PATH)</MonolithBranchRoot>
     <MonolithBranchRoot Condition="'$(MonolithBranchRoot)' == ''">$([MSBuild]::GetRegistryValue('HKEY_CURRENT_USER\Environment', 'CCP_EVE_PERFORCE_BRANCH_PATH'))</MonolithBranchRoot>
-    <MonolithInstallPrefix Condition="'$(MonolithBranchRoot)' != ''">$(MonolithBranchRoot.Replace('\', '/'))/vendor/github.com/ccpgames/carbon-audio/develop</MonolithInstallPrefix>
+    <MonolithInstallPrefix Condition="'$(MonolithBranchRoot)' != ''">$(MonolithBranchRoot.Replace('\', '/'))/vendor/github.com/carbonengine/audio/develop</MonolithInstallPrefix>
     <MonolithInstallDirWin Condition="'$(MonolithBranchRoot)' != ''">$(MonolithBranchRoot)\vendor\github.com\carbonengine\audio\develop</MonolithInstallDirWin>
     <MonolithBuildDir>.cmake-build-monolith</MonolithBuildDir>
+    <VsScratchDir>$(ProjectDir)$(MonolithBuildDir)\.vs-installtomonolith\$(Platform)\$(Configuration)\</VsScratchDir>
     <RepoRoot>$(ProjectDir.Replace('\', '/'))</RepoRoot>
     <MonolithBuildScript>setlocal
 cd /d "$(ProjectDir)"
@@ -43,12 +44,16 @@ echo === CarbonAudio installed to $(MonolithInstallPrefix) ===
 </MonolithBuildScript>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Internal|x64'">
+    <IntDir>$(VsScratchDir)</IntDir>
+    <OutDir>$(VsScratchDir)</OutDir>
     <NMakeBuildCommandLine>$(MonolithBuildScript)</NMakeBuildCommandLine>
     <NMakeReBuildCommandLine>cd /d "$(ProjectDir)"
 if exist $(MonolithBuildDir) rmdir /s /q $(MonolithBuildDir)
+mkdir "$(VsScratchDir)" 2&gt;nul
 $(MonolithBuildScript)</NMakeReBuildCommandLine>
     <NMakeCleanCommandLine>cd /d "$(ProjectDir)"
 if exist $(MonolithBuildDir) rmdir /s /q $(MonolithBuildDir)
+mkdir "$(VsScratchDir)" 2&gt;nul
 if exist "$(MonolithInstallDirWin)" echo Removing install at: $(MonolithInstallDirWin)
 if exist "$(MonolithInstallDirWin)" rmdir /s /q "$(MonolithInstallDirWin)"</NMakeCleanCommandLine>
     <NMakeOutput>$(ProjectDir)$(MonolithBuildDir)\Internal\_audio2_internal.pyd</NMakeOutput>

--- a/InstallToMonolith.vcxproj
+++ b/InstallToMonolith.vcxproj
@@ -20,14 +20,10 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
-    <!--
-      CCP_EVE_PERFORCE_BRANCH_PATH points at the P4V branch root, e.g. D:\frontier-master.
-      Fall back to HKCU\Environment so a Visual Studio started before the variable
-      was set still picks it up without a restart.
-    -->
     <MonolithBranchRoot>$(CCP_EVE_PERFORCE_BRANCH_PATH)</MonolithBranchRoot>
     <MonolithBranchRoot Condition="'$(MonolithBranchRoot)' == ''">$([MSBuild]::GetRegistryValue('HKEY_CURRENT_USER\Environment', 'CCP_EVE_PERFORCE_BRANCH_PATH'))</MonolithBranchRoot>
     <MonolithInstallPrefix Condition="'$(MonolithBranchRoot)' != ''">$(MonolithBranchRoot.Replace('\', '/'))/vendor/github.com/ccpgames/carbon-audio/develop</MonolithInstallPrefix>
+    <MonolithInstallDirWin Condition="'$(MonolithBranchRoot)' != ''">$(MonolithBranchRoot)\vendor\github.com\ccpgames\carbon-audio\develop</MonolithInstallDirWin>
     <MonolithBuildDir>.cmake-build-monolith</MonolithBuildDir>
     <RepoRoot>$(ProjectDir.Replace('\', '/'))</RepoRoot>
     <MonolithBuildScript>setlocal
@@ -39,6 +35,9 @@ set "PATH_TO_VCPKG_ROOT=$(ProjectDir)vendor\github.com\microsoft\vcpkg"
 echo Installing CarbonAudio to: $(MonolithInstallPrefix)
 cmake -S . -B $(MonolithBuildDir) -G "Visual Studio 18 2026" "-DCMAKE_TOOLCHAIN_FILE=$(RepoRoot)vendor/github.com/microsoft/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=$(RepoRoot)vendor/github.com/carbonengine/vcpkg-registry/toolchains/x64-windows-145-carbon.cmake" "-DVCPKG_OVERLAY_TRIPLETS=$(RepoRoot)vendor/github.com/carbonengine/vcpkg-registry/triplets" -DVCPKG_TARGET_TRIPLET=x64-windows-internal -DVCPKG_HOST_TRIPLET=x64-windows-internal -DVCPKG_USE_HOST_TOOLS=ON -DINSTALL_TO_MONOLITH=ON -DBUILD_TESTING=OFF "-DCMAKE_INSTALL_PREFIX=$(MonolithInstallPrefix)"
 if errorlevel 1 exit /b 1
+rem Wipe any existing install so this build fully replaces it (cmake install never removes stale files).
+if exist "$(MonolithInstallDirWin)" echo Removing existing install at: $(MonolithInstallDirWin)
+if exist "$(MonolithInstallDirWin)" rmdir /s /q "$(MonolithInstallDirWin)"
 cmake --build $(MonolithBuildDir) --config Internal --target INSTALL
 if errorlevel 1 exit /b 1
 echo === CarbonAudio installed to $(MonolithInstallPrefix) ===
@@ -50,7 +49,9 @@ echo === CarbonAudio installed to $(MonolithInstallPrefix) ===
 if exist $(MonolithBuildDir) rmdir /s /q $(MonolithBuildDir)
 $(MonolithBuildScript)</NMakeReBuildCommandLine>
     <NMakeCleanCommandLine>cd /d "$(ProjectDir)"
-if exist $(MonolithBuildDir) rmdir /s /q $(MonolithBuildDir)</NMakeCleanCommandLine>
+if exist $(MonolithBuildDir) rmdir /s /q $(MonolithBuildDir)
+if exist "$(MonolithInstallDirWin)" echo Removing install at: $(MonolithInstallDirWin)
+if exist "$(MonolithInstallDirWin)" rmdir /s /q "$(MonolithInstallDirWin)"</NMakeCleanCommandLine>
     <NMakeOutput>$(ProjectDir)$(MonolithBuildDir)\Internal\_audio2_internal.pyd</NMakeOutput>
     <NMakePreprocessorDefinitions>WIN32;NDEBUG;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
   </PropertyGroup>

--- a/src/AudManager.cpp
+++ b/src/AudManager.cpp
@@ -543,6 +543,11 @@ bool AudManager::SetEmitterLineOfSightBlockage( AkGameObjectID emitterID, float 
 	return m_obstructionOcclusion->SetEmitterLineOfSightBlockage( emitterID, blockage );
 }
 
+float AudManager::GetEmitterOcclusion( AkGameObjectID emitterID ) const
+{
+	return m_obstructionOcclusion->GetEmitterOcclusion( emitterID );
+}
+
 void AudManager::ClearObstructionOcclusion()
 {
 	m_obstructionOcclusion->ClearAll();
@@ -550,22 +555,22 @@ void AudManager::ClearObstructionOcclusion()
 
 bool AudManager::GetObstructionOcclusionEnabled() const
 {
-	return m_obstructionOcclusion->GetObstructionOcclusionEnabled();
+	return m_obstructionOcclusion->IsEnabled();
 }
 
 void AudManager::SetObstructionOcclusionEnabled( bool value )
 {
-	m_obstructionOcclusion->SetObstructionOcclusionEnabled( value );
+	m_obstructionOcclusion->SetEnabled( value );
 }
 
 float AudManager::GetObstructionOcclusionFadeRate() const
 {
-	return m_obstructionOcclusion->GetObstructionOcclusionFadeRate();
+	return m_obstructionOcclusion->GetFadeRate();
 }
 
 void AudManager::SetObstructionOcclusionFadeRate( float value )
 {
-	m_obstructionOcclusion->SetObstructionOcclusionFadeRate( value );
+	m_obstructionOcclusion->SetFadeRate( value );
 }
 
 void AudManager::UpdateSettings( AudSettings* settings )

--- a/src/AudManager.cpp
+++ b/src/AudManager.cpp
@@ -80,6 +80,7 @@ AudManager::AudManager( IRoot* lockobj ) :
 	// Initialize sound prioritization system
 	m_soundPrioritization = new SoundPrioritization();
 	m_spatialAudioSettings = new SpatialAudioSettings();
+	m_obstructionOcclusion = new AudObstructionOcclusion();
 }
 
 AudManager::~AudManager()
@@ -87,6 +88,7 @@ AudManager::~AudManager()
 	// Clean up sound prioritization system
 	delete m_soundPrioritization;
 	delete m_spatialAudioSettings;
+	delete m_obstructionOcclusion;
 
 	if( GetState() == AudioState::Enabled )
 	{
@@ -116,6 +118,8 @@ void AudManager::Process()
 		{
 			m_soundPrioritization->CullAudio();
 		}
+
+		m_obstructionOcclusion->Update();
 
 		// Process bank requests, events, positions, RTPC, etc.
 		AK::SoundEngine::RenderAudio();
@@ -340,6 +344,11 @@ void AudManager::UnregisterGameObject( AkGameObjectID gameObjID )
 	{
 		m_soundPrioritization->UnregisterGameObject( gameObjID );
 	}
+
+	if( m_obstructionOcclusion )
+	{
+		m_obstructionOcclusion->RemoveEmitter( gameObjID );
+	}
 }
 
 bool AudManager::InitCommunication()
@@ -528,6 +537,36 @@ void AudManager::SetSpatialAudioGeometryEnabled( bool enabled )
 const bool AudManager::SpatialAudioIsSupported()
 {
 	return s_systemSupportsSpatialAudio;
+}
+
+bool AudManager::SetEmitterLineOfSightBlockage( AkGameObjectID emitterID, float blockage )
+{
+	return m_obstructionOcclusion->SetEmitterLineOfSightBlockage( emitterID, blockage );
+}
+
+void AudManager::ClearObstructionOcclusion()
+{
+	m_obstructionOcclusion->ClearAll();
+}
+
+bool AudManager::GetObstructionOcclusionEnabled() const
+{
+	return m_obstructionOcclusion->GetObstructionOcclusionEnabled();
+}
+
+void AudManager::SetObstructionOcclusionEnabled( bool value )
+{
+	m_obstructionOcclusion->SetObstructionOcclusionEnabled( value );
+}
+
+float AudManager::GetObstructionOcclusionFadeRate() const
+{
+	return m_obstructionOcclusion->GetObstructionOcclusionFadeRate();
+}
+
+void AudManager::SetObstructionOcclusionFadeRate( float value )
+{
+	m_obstructionOcclusion->SetObstructionOcclusionFadeRate( value );
 }
 
 void AudManager::UpdateSettings( AudSettings* settings )
@@ -776,6 +815,7 @@ void AudManager::Disable()
 	}
 
 	ClearBanks();
+	m_obstructionOcclusion->Reset();
   AudGeometry::ClearAllGeometry();
 #ifndef AK_OPTIMIZED
 	AK::SoundEngine::UnregisterResourceMonitorCallback(ResourceMonitorCallback);

--- a/src/AudManager.cpp
+++ b/src/AudManager.cpp
@@ -80,7 +80,7 @@ AudManager::AudManager( IRoot* lockobj ) :
 	// Initialize sound prioritization system
 	m_soundPrioritization = new SoundPrioritization();
 	m_spatialAudioSettings = new SpatialAudioSettings();
-	m_obstructionOcclusion = new AudObstructionOcclusion();
+	m_obstructionOcclusion = std::make_unique<AudObstructionOcclusion>( this );
 }
 
 AudManager::~AudManager()
@@ -88,7 +88,6 @@ AudManager::~AudManager()
 	// Clean up sound prioritization system
 	delete m_soundPrioritization;
 	delete m_spatialAudioSettings;
-	delete m_obstructionOcclusion;
 
 	if( GetState() == AudioState::Enabled )
 	{

--- a/src/AudManager.h
+++ b/src/AudManager.h
@@ -9,6 +9,7 @@
 #include "AudListener.h"
 #include "SoundPrioritization.h"
 #include "SpatialAudioSettings.h"
+#include "AudObstructionOcclusion.h"
 #include "LowLevelIO/LowLevelIOHook.h"
 #include <atomic>
 #include <memory>
@@ -122,6 +123,16 @@ public:
 	bool GetSpatialAudioGeometryEnabled() const;
 	// Enables or disables spatial audio geometry.
 	void SetSpatialAudioGeometryEnabled( bool enabled );
+	// Set a single line-of-sight blockage ratio for an emitter [0.0, 1.0]. 0 = clear line of sight.
+	bool SetEmitterLineOfSightBlockage( AkGameObjectID emitterID, float blockage );
+	// Fade all obstruction/occlusion values back to clear.
+	void ClearObstructionOcclusion();
+	// Enable or disable game-driven obstruction/occlusion processing.
+	bool GetObstructionOcclusionEnabled() const;
+	void SetObstructionOcclusionEnabled( bool value );
+	// How fast obstruction/occlusion values fade towards their targets, in units per second.
+	float GetObstructionOcclusionFadeRate() const;
+	void SetObstructionOcclusionFadeRate( float value );
 	// Can be called to see if the current platform supports spatial audio.
 	const bool SpatialAudioIsSupported();
 	// Stop all currently playing sounds on all game objects.
@@ -239,6 +250,7 @@ private:
 
 	SoundPrioritization* m_soundPrioritization;
 	SpatialAudioSettings* m_spatialAudioSettings;
+	AudObstructionOcclusion* m_obstructionOcclusion;
 
 	//  Map of game objects, used to guard Wwise callbacks
 	std::unordered_map<AkGameObjectID, AudGameObjResource*> m_callbackGameObjects;

--- a/src/AudManager.h
+++ b/src/AudManager.h
@@ -250,7 +250,7 @@ private:
 
 	SoundPrioritization* m_soundPrioritization;
 	SpatialAudioSettings* m_spatialAudioSettings;
-	AudObstructionOcclusion* m_obstructionOcclusion;
+	std::unique_ptr<AudObstructionOcclusion> m_obstructionOcclusion;
 
 	//  Map of game objects, used to guard Wwise callbacks
 	std::unordered_map<AkGameObjectID, AudGameObjResource*> m_callbackGameObjects;

--- a/src/AudManager.h
+++ b/src/AudManager.h
@@ -125,6 +125,8 @@ public:
 	void SetSpatialAudioGeometryEnabled( bool enabled );
 	// Set a single line-of-sight blockage ratio for an emitter [0.0, 1.0]. 0 = clear line of sight.
 	bool SetEmitterLineOfSightBlockage( AkGameObjectID emitterID, float blockage );
+	// Current, mid-fade occlusion value for an emitter. 0.0 if the emitter is clear or not tracked.
+	float GetEmitterOcclusion( AkGameObjectID emitterID ) const;
 	// Fade all obstruction/occlusion values back to clear.
 	void ClearObstructionOcclusion();
 	// Enable or disable game-driven obstruction/occlusion processing.

--- a/src/AudManager_Blue.cpp
+++ b/src/AudManager_Blue.cpp
@@ -49,6 +49,10 @@ const Be::ClassInfo* AudManager::ExposeToBlue()
 		MAP_PROPERTY( "transmissionLoss", GetTransmissionLoss, SetTransmissionLoss, "Per-mesh setting: transmission loss [0.0-1.0] applied to geometry surfaces when meshes are registered.")
 		MAP_PROPERTY( "enableDiffraction", GetEnableDiffraction, SetEnableDiffraction, "Per-mesh setting: enable or disable geometric diffraction on mesh geometry.")
 		MAP_PROPERTY( "enableDiffractionOnBoundaryEdges", GetEnableDiffractionOnBoundaryEdges, SetEnableDiffractionOnBoundaryEdges, "Per-mesh setting: switch to enable or disable geometric diffraction on boundary edges for this mesh.")
+
+		// Obstruction / occlusion
+		MAP_PROPERTY( "obstructionOcclusionEnabled", GetObstructionOcclusionEnabled, SetObstructionOcclusionEnabled, "Enable or disable game-driven obstruction/occlusion processing. Disabling fades all values back to clear.")
+		MAP_PROPERTY( "obstructionOcclusionFadeRate", GetObstructionOcclusionFadeRate, SetObstructionOcclusionFadeRate, "How fast obstruction/occlusion values fade towards their targets, in units per second. 0 = instantaneous.")
 		
 		MAP_METHOD_AND_WRAP
 		( 
@@ -158,6 +162,18 @@ const Be::ClassInfo* AudManager::ExposeToBlue()
 			"Set a global state in Wwise.\n"
 			":param stateGroup: The name of the state group the state belongs to in Wwise.\n"
 			":param stateName: The state you want to set in Wwise."
+		)
+		MAP_METHOD_AND_WRAP
+		(
+			"SetEmitterLineOfSightBlockage",
+			SetEmitterLineOfSightBlockage,
+			"Set a line-of-sight blockage ratio [0.0-1.0] for an emitter (0 = clear). Returns True if the emitter exists."
+		)
+		MAP_METHOD_AND_WRAP
+		(
+			"ClearObstructionOcclusion",
+			ClearObstructionOcclusion,
+			"Fade the obstruction/occlusion values of all tracked emitters back to clear."
 		)
 		MAP_METHOD_AND_WRAP
 		( 

--- a/src/AudManager_Blue.cpp
+++ b/src/AudManager_Blue.cpp
@@ -171,6 +171,14 @@ const Be::ClassInfo* AudManager::ExposeToBlue()
 		)
 		MAP_METHOD_AND_WRAP
 		(
+			"GetEmitterOcclusion",
+			GetEmitterOcclusion,
+			"Get the occlusion value currently applied to an emitter. This is the live, mid-fade value "
+			"rather than the target that was set, so it can be used to observe a fade in progress. "
+			"Returns 0.0 if the emitter is clear or is not being tracked."
+		)
+		MAP_METHOD_AND_WRAP
+		(
 			"ClearObstructionOcclusion",
 			ClearObstructionOcclusion,
 			"Fade the obstruction/occlusion values of all tracked emitters back to clear."

--- a/src/AudObstructionOcclusion.cpp
+++ b/src/AudObstructionOcclusion.cpp
@@ -2,7 +2,7 @@
 //
 // Creator: Phevos Rinis
 // Creation Date: Jul 2026
-// Copyright (c) 2026 CCP Games
+// Copyright (c) 2026 Fernis Creations
 //
 
 #include "AudObstructionOcclusion.h"

--- a/src/AudObstructionOcclusion.cpp
+++ b/src/AudObstructionOcclusion.cpp
@@ -64,5 +64,41 @@ void AudObstructionOcclusion::ClearAll()
 
 void AudObstructionOcclusion::FadingValue::SetTarget(float target, float fadeRate)
 {
+	targetValue = std::clamp(target, 0.0f, 1.0f);
 
+	if (targetValue >= currentValue)
+	{
+		rate = fadeRate;
+	}
+	else
+	{
+		rate = -fadeRate;
+	}
+}
+
+bool AudObstructionOcclusion::FadingValue::Advance(float deltaSeconds)
+{
+	if (currentValue == targetValue)
+	{
+		return false;
+	}
+
+	if (rate == 0.0f)
+	{
+		currentValue = targetValue;
+		return true;
+	}
+
+	const float oldValue = currentValue;
+	const float newValue = oldValue + rate * deltaSeconds;
+
+	if (oldValue > targetValue)
+	{
+		currentValue = std::clamp(newValue, targetValue, oldValue);
+	}
+	else
+	{
+		currentValue = std::clamp(newValue, oldValue, targetValue);
+	}
+	return currentValue != oldValue;
 }

--- a/src/AudObstructionOcclusion.cpp
+++ b/src/AudObstructionOcclusion.cpp
@@ -19,7 +19,70 @@ AudObstructionOcclusion::~AudObstructionOcclusion()
 {}
 
 void AudObstructionOcclusion::Update()
-{}
+{
+
+	if (g_audioManager == nullptr || g_audioManager->GetState() != AudioState::Enabled)
+	{
+		return;
+	}
+
+	const auto now = std::chrono::steady_clock::now();
+	float detlaSeconds = 0.0f;
+
+	if (m_hasUpdated)
+	{
+		detlaSeconds = std::chrono::duration<float>(now - m_lastUpdateTime).count();
+	}
+	m_lastUpdateTime = now;
+	m_hasUpdated = true;
+
+	CcpAutoMutex lock( m_mutex );
+
+	for (auto it = m_emitters.begin(); it != m_emitters.end();)
+	{
+		const AkGameObjectID emitterID = it->first;
+		EmitterState& state = it->second;
+
+		bool culled = false;
+		const bool exists = g_audioManager->WithCallbackGameObject(emitterID, [&culled](AudGameObjResource* emitter) {
+			culled = emitter->IsCulled();
+			});
+
+		if (!exists)
+		{
+			it = m_emitters.erase(it);
+			continue;
+		}
+
+		const bool obstructionChanged = state.obstruction.Advance(detlaSeconds);
+		const bool occlusionChanged = state.occlusion.Advance(detlaSeconds);
+
+		if (culled)
+		{
+			// The emitter is outside Wwise's view. Keep fading so time stays
+			// consistent, and make sure the values are resent once the emitter wakes up.
+			state.needsSend = true;
+			++it;
+			continue;
+		}
+
+		if (obstructionChanged || occlusionChanged || state.needsSend)
+		{
+			state.needsSend = !SendToWwise(emitterID, state);
+		}
+
+		// Remove the emitter from the list if it has reached its target values and is no longer needed.
+		if (!state.needsSend &&
+			state.obstruction.ReachedTarget() && state.obstruction.targetValue == 0.0f &&
+			state.occlusion.ReachedTarget() && state.occlusion.targetValue == 0.0f)
+		{
+			it = m_emitters.erase(it);
+			continue;
+		}
+
+		++it;
+	}
+}
 
 bool AudObstructionOcclusion::SetObstructionOcclusion(AkGameObjectID emitterID, float obstruction, float occlusion)
 {

--- a/src/AudObstructionOcclusion.cpp
+++ b/src/AudObstructionOcclusion.cpp
@@ -1,0 +1,10 @@
+////////////////////////////////////////////////////////////
+//
+// Creator: Phevos Rinis
+// Creation Date: Jul 2026
+// Copyright (c) 2026 CCP Games
+//
+
+#include "AudObstructionOcclusion.h"
+#include "AudManager.h"
+

--- a/src/AudObstructionOcclusion.cpp
+++ b/src/AudObstructionOcclusion.cpp
@@ -74,14 +74,6 @@ void AudObstructionOcclusion::Update()
 			state.needsSend = !SendToWwise(emitterID, state);
 		}
 
-		// Remove the emitter from the list if it has reached its target values and is no longer needed.
-		if (!state.needsSend &&
-			state.obstruction.ReachedTarget() && state.obstruction.targetValue == 0.0f &&
-			state.occlusion.ReachedTarget() && state.occlusion.targetValue == 0.0f)
-		{
-			it = m_emitters.erase(it);
-			continue;
-		}
 
 		++it;
 	}
@@ -112,10 +104,18 @@ bool AudObstructionOcclusion::SetObstructionOcclusion(AkGameObjectID emitterID, 
 	}
 
 	CcpAutoMutex lock(m_mutex);
-	EmitterState& state = m_emitters[emitterID];
+
+	const auto [entry, isNewEmitter] = m_emitters.try_emplace(emitterID);
+	EmitterState& state = entry->second;
 
 	state.obstruction.SetTarget(obstruction);
 	state.occlusion.SetTarget(occlusion);
+
+	if (isNewEmitter)
+	{
+		state.obstruction.SnapToTarget();
+		state.occlusion.SnapToTarget();
+	}
 
 	return true;
 }

--- a/src/AudObstructionOcclusion.cpp
+++ b/src/AudObstructionOcclusion.cpp
@@ -8,3 +8,30 @@
 #include "AudObstructionOcclusion.h"
 #include "AudManager.h"
 
+AudObstructionOcclusion::AudObstructionOcclusion()
+{}
+
+AudObstructionOcclusion::~AudObstructionOcclusion()
+{}
+
+void AudObstructionOcclusion::Update()
+{}
+
+bool AudObstructionOcclusion::SetObstructionOcclusion(AkGameObjectID emitterID, float obstruction, float occlusion)
+{
+	return false;
+}
+
+bool AudObstructionOcclusion::SetEmitterLineOfSightBlockage(AkGameObjectID emitterID, float blockage)
+{
+	return false;
+}
+
+void AudObstructionOcclusion::RemoveEmitter(AkGameObjectID emitterID)
+{}
+
+void AudObstructionOcclusion::Reset()
+{}
+
+void AudObstructionOcclusion::ClearAll()
+{}

--- a/src/AudObstructionOcclusion.cpp
+++ b/src/AudObstructionOcclusion.cpp
@@ -85,6 +85,17 @@ void AudObstructionOcclusion::Update()
 
 bool AudObstructionOcclusion::SetObstructionOcclusion(AkGameObjectID emitterID, float obstruction, float occlusion)
 {
+	if (g_audioManager == nullptr || g_audioManager->GetState() != AudioState::Enabled)
+	{
+		return false;
+	}
+
+	// Values are relative to the listener, so setting them on the listener itself is meaningless.
+	if (emitterID == LISTENER_GAME_OBJ_ID)
+	{
+		return false;
+	}
+
 	// We need to ask AudioManager about emitters that actually exist.
 	if (!g_audioManager->WithCallbackGameObject(emitterID, [](AudGameObjResource*) {}))
 	{

--- a/src/AudObstructionOcclusion.cpp
+++ b/src/AudObstructionOcclusion.cpp
@@ -102,7 +102,17 @@ bool AudObstructionOcclusion::SetObstructionOcclusion(AkGameObjectID emitterID, 
 
 bool AudObstructionOcclusion::SetEmitterLineOfSightBlockage(AkGameObjectID emitterID, float blockage)
 {
-	return false;
+	// When Acoustics is On its transmission already attenuates, so skip occlusion to avoid stacking.
+	// Might change in the future with the addition of volumes.
+	const bool acousticsEnabled = g_audioManager != nullptr && g_audioManager->GetSpatialAudioGeometryEnabled();
+
+	float occlusion = 0.0f;
+	if (!acousticsEnabled)
+	{
+		occlusion = blockage;
+	}
+
+	return SetObstructionOcclusion(emitterID, 0.0f, occlusion);
 }
 
 bool AudObstructionOcclusion::SendToWwise(AkGameObjectID emitterID, const EmitterState& state) const

--- a/src/AudObstructionOcclusion.cpp
+++ b/src/AudObstructionOcclusion.cpp
@@ -10,7 +10,8 @@
 
 #include <algorithm>
 
-AudObstructionOcclusion::AudObstructionOcclusion()	:
+AudObstructionOcclusion::AudObstructionOcclusion(AudManager* audioManager)	:
+	m_audioManager(audioManager),
 	m_fadeRate(DEFAULT_FADE_RATE),
 	m_hasUpdated(false),
 	m_enabled(true),
@@ -23,7 +24,7 @@ AudObstructionOcclusion::~AudObstructionOcclusion()
 void AudObstructionOcclusion::Update()
 {
 
-	if (g_audioManager == nullptr || g_audioManager->GetState() != AudioState::Enabled)
+	if (m_audioManager == nullptr || m_audioManager->GetState() != AudioState::Enabled)
 	{
 		return;
 	}
@@ -46,7 +47,7 @@ void AudObstructionOcclusion::Update()
 		EmitterState& state = it->second;
 
 		bool culled = false;
-		const bool exists = g_audioManager->WithCallbackGameObject(emitterID, [&culled](AudGameObjResource* emitter) {
+		const bool exists = m_audioManager->WithCallbackGameObject(emitterID, [&culled](AudGameObjResource* emitter) {
 			culled = emitter->IsCulled();
 			});
 
@@ -56,8 +57,8 @@ void AudObstructionOcclusion::Update()
 			continue;
 		}
 
-		const bool obstructionChanged = state.obstruction.Advance(deltaSeconds);
-		const bool occlusionChanged = state.occlusion.Advance(deltaSeconds);
+		const bool obstructionChanged = state.obstruction.Advance(deltaSeconds, m_fadeRate);
+		const bool occlusionChanged = state.occlusion.Advance(deltaSeconds, m_fadeRate);
 
 		if (culled)
 		{
@@ -93,7 +94,7 @@ bool AudObstructionOcclusion::SetObstructionOcclusion(AkGameObjectID emitterID, 
 		return false;
 	}
 
-	if (g_audioManager == nullptr || g_audioManager->GetState() != AudioState::Enabled)
+	if (m_audioManager == nullptr || m_audioManager->GetState() != AudioState::Enabled)
 	{
 		return false;
 	}
@@ -105,7 +106,7 @@ bool AudObstructionOcclusion::SetObstructionOcclusion(AkGameObjectID emitterID, 
 	}
 
 	// We need to ask AudioManager about emitters that actually exist.
-	if (!g_audioManager->WithCallbackGameObject(emitterID, [](AudGameObjResource*) {}))
+	if (!m_audioManager->WithCallbackGameObject(emitterID, [](AudGameObjResource*) {}))
 	{
 		return false;
 	}
@@ -113,8 +114,8 @@ bool AudObstructionOcclusion::SetObstructionOcclusion(AkGameObjectID emitterID, 
 	CcpAutoMutex lock(m_mutex);
 	EmitterState& state = m_emitters[emitterID];
 
-	state.obstruction.SetTarget(obstruction, m_fadeRate);
-	state.occlusion.SetTarget(occlusion, m_fadeRate);
+	state.obstruction.SetTarget(obstruction);
+	state.occlusion.SetTarget(occlusion);
 
 	return true;
 }
@@ -123,7 +124,7 @@ bool AudObstructionOcclusion::SetEmitterLineOfSightBlockage(AkGameObjectID emitt
 {
 	// When Acoustics is On its transmission already attenuates, so skip occlusion to avoid stacking.
 	// Might change in the future with the addition of volumes.
-	const bool acousticsEnabled = g_audioManager != nullptr && g_audioManager->GetSpatialAudioGeometryEnabled();
+	const bool acousticsEnabled = m_audioManager != nullptr && m_audioManager->GetSpatialAudioGeometryEnabled();
 
 	float occlusion = 0.0f;
 	if (!acousticsEnabled)
@@ -162,8 +163,8 @@ void AudObstructionOcclusion::ClearAll()
 	CcpAutoMutex lock(m_mutex);
 	for (auto& pair : m_emitters)
 	{
-		pair.second.obstruction.SetTarget(0.0f, m_fadeRate);
-		pair.second.occlusion.SetTarget(0.0f, m_fadeRate);
+		pair.second.obstruction.SetTarget(0.0f);
+		pair.second.occlusion.SetTarget(0.0f);
 	}
 }
 
@@ -196,43 +197,34 @@ void AudObstructionOcclusion::SetObstructionOcclusionFadeRate(float value)
 	m_fadeRate = std::max(value, 0.0f);
 }
 
-void AudObstructionOcclusion::FadingValue::SetTarget(float target, float fadeRate)
+void AudObstructionOcclusion::FadingValue::SetTarget(float target)
 {
 	targetValue = std::clamp(target, 0.0f, 1.0f);
-
-	if (targetValue >= currentValue)
-	{
-		rate = fadeRate;
-	}
-	else
-	{
-		rate = -fadeRate;
-	}
 }
 
-bool AudObstructionOcclusion::FadingValue::Advance(float deltaSeconds)
+bool AudObstructionOcclusion::FadingValue::Advance(float deltaSeconds, float fadeRate)
 {
 	if (currentValue == targetValue)
 	{
 		return false;
 	}
 
-	if (rate == 0.0f)
+	if (fadeRate <= 0.0f)
 	{
 		currentValue = targetValue;
 		return true;
 	}
 
 	const float oldValue = currentValue;
-	const float newValue = oldValue + rate * deltaSeconds;
+	const float step = fadeRate * deltaSeconds;
 
 	if (oldValue > targetValue)
 	{
-		currentValue = std::clamp(newValue, targetValue, oldValue);
+		currentValue = std::clamp(oldValue - step, targetValue, oldValue);
 	}
 	else
 	{
-		currentValue = std::clamp(newValue, oldValue, targetValue);
+		currentValue = std::clamp(oldValue + step, oldValue, targetValue);
 	}
 	return currentValue != oldValue;
 }

--- a/src/AudObstructionOcclusion.cpp
+++ b/src/AudObstructionOcclusion.cpp
@@ -135,6 +135,19 @@ bool AudObstructionOcclusion::SetEmitterLineOfSightBlockage(AkGameObjectID emitt
 	return SetObstructionOcclusion(emitterID, 0.0f, occlusion);
 }
 
+float AudObstructionOcclusion::GetEmitterOcclusion(AkGameObjectID emitterID) const
+{
+	CcpAutoMutex lock(m_mutex);
+
+	auto it = m_emitters.find(emitterID);
+	if (it == m_emitters.end())
+	{
+		return 0.0f;
+	}
+
+	return it->second.occlusion.currentValue;
+}
+
 bool AudObstructionOcclusion::SendToWwise(AkGameObjectID emitterID, const EmitterState& state) const
 {
 	const AKRESULT result = AK::SoundEngine::SetObjectObstructionAndOcclusion(
@@ -168,12 +181,12 @@ void AudObstructionOcclusion::ClearAll()
 	}
 }
 
-bool AudObstructionOcclusion::GetObstructionOcclusionEnabled() const
+bool AudObstructionOcclusion::IsEnabled() const
 {
 	return m_enabled;
 }
 
-void AudObstructionOcclusion::SetObstructionOcclusionEnabled(bool value)
+void AudObstructionOcclusion::SetEnabled(bool value)
 {
 	if (m_enabled == value)
 	{
@@ -187,12 +200,12 @@ void AudObstructionOcclusion::SetObstructionOcclusionEnabled(bool value)
 	}
 }
 
-float AudObstructionOcclusion::GetObstructionOcclusionFadeRate() const
+float AudObstructionOcclusion::GetFadeRate() const
 {
 	return m_fadeRate;
 }
 
-void AudObstructionOcclusion::SetObstructionOcclusionFadeRate(float value)
+void AudObstructionOcclusion::SetFadeRate(float value)
 {
 	m_fadeRate = std::max(value, 0.0f);
 }

--- a/src/AudObstructionOcclusion.cpp
+++ b/src/AudObstructionOcclusion.cpp
@@ -27,6 +27,16 @@ bool AudObstructionOcclusion::SetEmitterLineOfSightBlockage(AkGameObjectID emitt
 	return false;
 }
 
+bool AudObstructionOcclusion::SendToWwise(AkGameObjectID emitterID, const EmitterState& state) const
+{
+	const AKRESULT result = AK::SoundEngine::SetObjectObstructionAndOcclusion(
+		emitterID,
+		LISTENER_GAME_OBJ_ID,
+		state.obstruction.currentValue,
+		state.occlusion.currentValue);
+	return result == AK_Success;
+
+
 void AudObstructionOcclusion::RemoveEmitter(AkGameObjectID emitterID)
 {}
 

--- a/src/AudObstructionOcclusion.cpp
+++ b/src/AudObstructionOcclusion.cpp
@@ -8,6 +8,8 @@
 #include "AudObstructionOcclusion.h"
 #include "AudManager.h"
 
+#include <algorithm>
+
 AudObstructionOcclusion::AudObstructionOcclusion()	:
 	m_fadeRate(DEFAULT_FADE_RATE),
 	m_hasUpdated(false),
@@ -182,6 +184,16 @@ void AudObstructionOcclusion::SetObstructionOcclusionEnabled(bool value)
 	{
 		ClearAll();
 	}
+}
+
+float AudObstructionOcclusion::GetObstructionOcclusionFadeRate() const
+{
+	return m_fadeRate;
+}
+
+void AudObstructionOcclusion::SetObstructionOcclusionFadeRate(float value)
+{
+	m_fadeRate = std::max(value, 0.0f);
 }
 
 void AudObstructionOcclusion::FadingValue::SetTarget(float target, float fadeRate)

--- a/src/AudObstructionOcclusion.cpp
+++ b/src/AudObstructionOcclusion.cpp
@@ -10,9 +10,8 @@
 
 AudObstructionOcclusion::AudObstructionOcclusion()	:
 	m_fadeRate(0.0f),
-	m_enabled(false),
 	m_hasUpdated(false),
-	m_mutex("AudObstructionOcclusion;", "m_mutex")
+	m_mutex("AudObstructionOcclusion", "m_mutex")
 {}
 
 AudObstructionOcclusion::~AudObstructionOcclusion()
@@ -27,11 +26,11 @@ void AudObstructionOcclusion::Update()
 	}
 
 	const auto now = std::chrono::steady_clock::now();
-	float detlaSeconds = 0.0f;
+	float deltaSeconds = 0.0f;
 
 	if (m_hasUpdated)
 	{
-		detlaSeconds = std::chrono::duration<float>(now - m_lastUpdateTime).count();
+		deltaSeconds = std::chrono::duration<float>(now - m_lastUpdateTime).count();
 	}
 	m_lastUpdateTime = now;
 	m_hasUpdated = true;
@@ -54,8 +53,8 @@ void AudObstructionOcclusion::Update()
 			continue;
 		}
 
-		const bool obstructionChanged = state.obstruction.Advance(detlaSeconds);
-		const bool occlusionChanged = state.occlusion.Advance(detlaSeconds);
+		const bool obstructionChanged = state.obstruction.Advance(deltaSeconds);
+		const bool occlusionChanged = state.occlusion.Advance(deltaSeconds);
 
 		if (culled)
 		{

--- a/src/AudObstructionOcclusion.cpp
+++ b/src/AudObstructionOcclusion.cpp
@@ -9,7 +9,7 @@
 #include "AudManager.h"
 
 AudObstructionOcclusion::AudObstructionOcclusion()	:
-	m_fadeRate(0.0f),
+	m_fadeRate(DEFAULT_FADE_RATE),
 	m_hasUpdated(false),
 	m_mutex("AudObstructionOcclusion", "m_mutex")
 {}

--- a/src/AudObstructionOcclusion.cpp
+++ b/src/AudObstructionOcclusion.cpp
@@ -11,6 +11,7 @@
 AudObstructionOcclusion::AudObstructionOcclusion()	:
 	m_fadeRate(DEFAULT_FADE_RATE),
 	m_hasUpdated(false),
+	m_enabled(true),
 	m_mutex("AudObstructionOcclusion", "m_mutex")
 {}
 
@@ -85,6 +86,11 @@ void AudObstructionOcclusion::Update()
 
 bool AudObstructionOcclusion::SetObstructionOcclusion(AkGameObjectID emitterID, float obstruction, float occlusion)
 {
+	if (!m_enabled)
+	{
+		return false;
+	}
+
 	if (g_audioManager == nullptr || g_audioManager->GetState() != AudioState::Enabled)
 	{
 		return false;
@@ -156,6 +162,25 @@ void AudObstructionOcclusion::ClearAll()
 	{
 		pair.second.obstruction.SetTarget(0.0f, m_fadeRate);
 		pair.second.occlusion.SetTarget(0.0f, m_fadeRate);
+	}
+}
+
+bool AudObstructionOcclusion::GetObstructionOcclusionEnabled() const
+{
+	return m_enabled;
+}
+
+void AudObstructionOcclusion::SetObstructionOcclusionEnabled(bool value)
+{
+	if (m_enabled == value)
+	{
+		return;
+	}
+
+	m_enabled = value;
+	if (!m_enabled)
+	{
+		ClearAll();
 	}
 }
 

--- a/src/AudObstructionOcclusion.cpp
+++ b/src/AudObstructionOcclusion.cpp
@@ -8,7 +8,11 @@
 #include "AudObstructionOcclusion.h"
 #include "AudManager.h"
 
-AudObstructionOcclusion::AudObstructionOcclusion()
+AudObstructionOcclusion::AudObstructionOcclusion()	:
+	m_fadeRate(0.0f),
+	m_enabled(false),
+	m_hasUpdated(false),
+	m_mutex("AudObstructionOcclusion;", "m_mutex")
 {}
 
 AudObstructionOcclusion::~AudObstructionOcclusion()
@@ -19,7 +23,19 @@ void AudObstructionOcclusion::Update()
 
 bool AudObstructionOcclusion::SetObstructionOcclusion(AkGameObjectID emitterID, float obstruction, float occlusion)
 {
-	return false;
+	// We need to ask AudioManager about emitters that actually exist.
+	if (!g_audioManager->WithCallbackGameObject(emitterID, [](AudGameObjResource*) {}))
+	{
+		return false;
+	}
+
+	CcpAutoMutex lock(m_mutex);
+	EmitterState& state = m_emitters[emitterID];
+
+	state.obstruction.SetTarget(obstruction, m_fadeRate);
+	state.occlusion.SetTarget(occlusion, m_fadeRate);
+
+	return true;
 }
 
 bool AudObstructionOcclusion::SetEmitterLineOfSightBlockage(AkGameObjectID emitterID, float blockage)
@@ -35,7 +51,7 @@ bool AudObstructionOcclusion::SendToWwise(AkGameObjectID emitterID, const Emitte
 		state.obstruction.currentValue,
 		state.occlusion.currentValue);
 	return result == AK_Success;
-
+}
 
 void AudObstructionOcclusion::RemoveEmitter(AkGameObjectID emitterID)
 {}
@@ -45,3 +61,8 @@ void AudObstructionOcclusion::Reset()
 
 void AudObstructionOcclusion::ClearAll()
 {}
+
+void AudObstructionOcclusion::FadingValue::SetTarget(float target, float fadeRate)
+{
+
+}

--- a/src/AudObstructionOcclusion.cpp
+++ b/src/AudObstructionOcclusion.cpp
@@ -116,13 +116,27 @@ bool AudObstructionOcclusion::SendToWwise(AkGameObjectID emitterID, const Emitte
 }
 
 void AudObstructionOcclusion::RemoveEmitter(AkGameObjectID emitterID)
-{}
+{
+	CcpAutoMutex lock(m_mutex);
+	m_emitters.erase(emitterID);
+}
 
 void AudObstructionOcclusion::Reset()
-{}
+{
+	CcpAutoMutex lock(m_mutex);
+	m_emitters.clear();
+	m_hasUpdated = false;
+}
 
 void AudObstructionOcclusion::ClearAll()
-{}
+{
+	CcpAutoMutex lock(m_mutex);
+	for (auto& pair : m_emitters)
+	{
+		pair.second.obstruction.SetTarget(0.0f, m_fadeRate);
+		pair.second.occlusion.SetTarget(0.0f, m_fadeRate);
+	}
+}
 
 void AudObstructionOcclusion::FadingValue::SetTarget(float target, float fadeRate)
 {

--- a/src/AudObstructionOcclusion.h
+++ b/src/AudObstructionOcclusion.h
@@ -9,6 +9,20 @@
 
 #include <AK/SoundEngine/Common/AkTypes.h> 
 
+struct FadingValue
+{
+	float currentValue = 0.0f;
+	float targetValue = 0.0f;
+	float rate = 0.0f;
+};
+
+struct EmitterState
+{
+	FadingValue obstruction;
+	FadingValue occlusion;
+
+};
+
 class AudObstructionOcclusion
 {
 public:
@@ -21,6 +35,8 @@ public:
 	bool SetObstructionOcclusion(AkGameObjectID emitterID, float obstruction, float occlusion);
 
 	bool SetEmitterLineOfSightBlockage(AkGameObjectID emitterID, float blockage);
+
+	bool SendToWwise(AkGameObjectID emitterID, const EmitterState& state) const;
 
 	void RemoveEmitter( AkGameObjectID emitterID );
 

--- a/src/AudObstructionOcclusion.h
+++ b/src/AudObstructionOcclusion.h
@@ -36,6 +36,9 @@ public:
 	bool GetObstructionOcclusionEnabled() const;
 	void SetObstructionOcclusionEnabled(bool value);
 
+	float GetObstructionOcclusionFadeRate() const;
+	void SetObstructionOcclusionFadeRate(float value);
+
 private:
 
 	struct FadingValue

--- a/src/AudObstructionOcclusion.h
+++ b/src/AudObstructionOcclusion.h
@@ -9,20 +9,6 @@
 
 #include <AK/SoundEngine/Common/AkTypes.h> 
 
-struct FadingValue
-{
-	float currentValue = 0.0f;
-	float targetValue = 0.0f;
-	float rate = 0.0f;
-};
-
-struct EmitterState
-{
-	FadingValue obstruction;
-	FadingValue occlusion;
-
-};
-
 class AudObstructionOcclusion
 {
 public:
@@ -36,11 +22,40 @@ public:
 
 	bool SetEmitterLineOfSightBlockage(AkGameObjectID emitterID, float blockage);
 
-	bool SendToWwise(AkGameObjectID emitterID, const EmitterState& state) const;
-
 	void RemoveEmitter( AkGameObjectID emitterID );
 
 	void Reset();
 
 	void ClearAll();
+
+private:
+
+	struct FadingValue
+	{
+		float currentValue = 0.0f;
+		float targetValue = 0.0f;
+		float rate = 0.0f;
+
+		void SetTarget(float target, float fadeRate);
+		bool Advance(float deltaSeconds);
+		bool ReachedTarget() const { return currentValue == targetValue; };
+	};
+
+	struct EmitterState
+	{
+		FadingValue obstruction;
+		FadingValue occlusion;
+
+		bool needsSend = true;
+
+	};
+
+	bool SendToWwise(AkGameObjectID emitterID, const EmitterState& state) const;
+
+	std::unordered_map<AkGameObjectID, EmitterState> m_emitters;
+	float m_fadeRate;
+	bool m_enabled;
+	bool m_hasUpdated;
+	mutable CcpMutex m_mutex;
+
 };

--- a/src/AudObstructionOcclusion.h
+++ b/src/AudObstructionOcclusion.h
@@ -14,11 +14,13 @@
 
 #include <CcpMutex.h>
 
+class AudManager;
+
 class AudObstructionOcclusion
 {
 public:
 
-	AudObstructionOcclusion();
+	AudObstructionOcclusion(AudManager* audioManager);
 	~AudObstructionOcclusion();
 
 	void Update();
@@ -45,10 +47,9 @@ private:
 	{
 		float currentValue = 0.0f;
 		float targetValue = 0.0f;
-		float rate = 0.0f;
 
-		void SetTarget(float target, float fadeRate);
-		bool Advance(float deltaSeconds);
+		void SetTarget(float target);
+		bool Advance(float deltaSeconds, float fadeRate);
 		bool ReachedTarget() const { return currentValue == targetValue; };
 	};
 
@@ -66,6 +67,7 @@ private:
 	// Fades from clear to fully blocked in one second.
 	static constexpr float DEFAULT_FADE_RATE = 1.0f;
 
+	AudManager* m_audioManager;
 	std::unordered_map<AkGameObjectID, EmitterState> m_emitters;
 	float m_fadeRate;
 	bool m_hasUpdated;

--- a/src/AudObstructionOcclusion.h
+++ b/src/AudObstructionOcclusion.h
@@ -57,6 +57,9 @@ private:
 
 	bool SendToWwise(AkGameObjectID emitterID, const EmitterState& state) const;
 
+	// Fades from clear to fully blocked in one second.
+	static constexpr float DEFAULT_FADE_RATE = 1.0f;
+
 	std::unordered_map<AkGameObjectID, EmitterState> m_emitters;
 	float m_fadeRate;
 	bool m_hasUpdated;

--- a/src/AudObstructionOcclusion.h
+++ b/src/AudObstructionOcclusion.h
@@ -16,6 +16,15 @@
 
 class AudManager;
 
+/**
+ * @brief Owns the obstruction and occlusion of every emitter and feeds those values to Wwise.
+ *
+ * The game tells us how much of an emitter's line of sight to the listener is blocked, and this
+ * class turns that into the obstruction and occlusion Wwise applies
+ * (see @c AK::SoundEngine::SetObjectObstructionAndOcclusion). Each
+ * value fades towards its target so that sounds do not pop when something moves in front of them.
+ *
+ */
 class AudObstructionOcclusion
 {
 public:
@@ -23,26 +32,61 @@ public:
 	AudObstructionOcclusion(AudManager* audioManager);
 	~AudObstructionOcclusion();
 
+	/**
+	 * @brief Advances every fade and sends the values that changed to Wwise.
+	 */
 	void Update();
 
+	/**
+	 * @brief Sets the obstruction and occlusion an emitter fades towards.
+	 *
+	 * @param emitterID   The emitter to block.
+	 * @param obstruction Target obstruction [0.0, 1.0]
+	 * @param occlusion   Target occlusion [0.0, 1.0]
+	 *
+	 * @return True if the emitter exists and the values were accepted.
+	 */
 	bool SetObstructionOcclusion(AkGameObjectID emitterID, float obstruction, float occlusion);
 
+	/**
+	 * @brief Sets how much of an emitter's line of sight to the listener is blocked.
+	 *
+	 * @param emitterID The emitter to block.
+	 * @param blockage  How blocked the line of sight is [0.0, 1.0]. 0 is a clear line of sight.
+	 *
+	 * @return True if the emitter exists and the value was accepted.
+	 */
 	bool SetEmitterLineOfSightBlockage(AkGameObjectID emitterID, float blockage);
 
+	/**
+	 * @brief The occlusion currently applied to an emitter.
+	 */
+	float GetEmitterOcclusion(AkGameObjectID emitterID) const;
+
+	/// Drops an emitter straight away without fading it out, for when the game object goes away.
 	void RemoveEmitter( AkGameObjectID emitterID );
 
+	/// Forgets every emitter and the fade clock, for when audio is disabled.
 	void Reset();
 
+	/// Fades every tracked emitter back to clear and keeps them around until they get there.
 	void ClearAll();
 
-	bool GetObstructionOcclusionEnabled() const;
-	void SetObstructionOcclusionEnabled(bool value);
+	/**
+	 * @brief Controls whether game driven obstruction and occlusion is processed at all.
+	 */
+	bool IsEnabled() const;
+	void SetEnabled(bool value);
 
-	float GetObstructionOcclusionFadeRate() const;
-	void SetObstructionOcclusionFadeRate(float value);
+	/**
+	 * @brief How fast values move towards their target, in units per second.
+	 */
+	float GetFadeRate() const;
+	void SetFadeRate(float value);
 
 private:
 
+	/// A single value on its way to a target, and the maths that moves it there.
 	struct FadingValue
 	{
 		float currentValue = 0.0f;
@@ -53,6 +97,7 @@ private:
 		bool ReachedTarget() const { return currentValue == targetValue; };
 	};
 
+	/// Everything we keep for one blocked emitter.
 	struct EmitterState
 	{
 		FadingValue obstruction;
@@ -64,7 +109,6 @@ private:
 
 	bool SendToWwise(AkGameObjectID emitterID, const EmitterState& state) const;
 
-	// Fades from clear to fully blocked in one second.
 	static constexpr float DEFAULT_FADE_RATE = 1.0f;
 
 	AudManager* m_audioManager;

--- a/src/AudObstructionOcclusion.h
+++ b/src/AudObstructionOcclusion.h
@@ -7,7 +7,12 @@
 
 #pragma once
 
-#include <AK/SoundEngine/Common/AkTypes.h> 
+#include <chrono>
+#include <unordered_map>
+
+#include <AK/SoundEngine/Common/AkTypes.h>
+
+#include <CcpMutex.h>
 
 class AudObstructionOcclusion
 {
@@ -54,7 +59,6 @@ private:
 
 	std::unordered_map<AkGameObjectID, EmitterState> m_emitters;
 	float m_fadeRate;
-	bool m_enabled;
 	bool m_hasUpdated;
 	mutable CcpMutex m_mutex;
 

--- a/src/AudObstructionOcclusion.h
+++ b/src/AudObstructionOcclusion.h
@@ -7,5 +7,24 @@
 
 #pragma once
 
+#include <AK/SoundEngine/Common/AkTypes.h> 
+
 class AudObstructionOcclusion
-{}
+{
+public:
+
+	AudObstructionOcclusion();
+	~AudObstructionOcclusion();
+
+	void Update();
+
+	bool SetObstructionOcclusion(AkGameObjectID emitterID, float obstruction, float occlusion);
+
+	bool SetEmitterLineOfSightBlockage(AkGameObjectID emitterID, float blockage);
+
+	void RemoveEmitter( AkGameObjectID emitterID );
+
+	void Reset();
+
+	void ClearAll();
+};

--- a/src/AudObstructionOcclusion.h
+++ b/src/AudObstructionOcclusion.h
@@ -1,0 +1,11 @@
+////////////////////////////////////////////////////////////
+//
+// Creator: Phevos Rinis
+// Creation Date: Jul 2026
+// Copyright (c) 2026 CCP Games
+//
+
+#pragma once
+
+class AudObstructionOcclusion
+{}

--- a/src/AudObstructionOcclusion.h
+++ b/src/AudObstructionOcclusion.h
@@ -58,4 +58,6 @@ private:
 	bool m_hasUpdated;
 	mutable CcpMutex m_mutex;
 
+	std::chrono::steady_clock::time_point m_lastUpdateTime;
+
 };

--- a/src/AudObstructionOcclusion.h
+++ b/src/AudObstructionOcclusion.h
@@ -33,6 +33,9 @@ public:
 
 	void ClearAll();
 
+	bool GetObstructionOcclusionEnabled() const;
+	void SetObstructionOcclusionEnabled(bool value);
+
 private:
 
 	struct FadingValue
@@ -63,6 +66,7 @@ private:
 	std::unordered_map<AkGameObjectID, EmitterState> m_emitters;
 	float m_fadeRate;
 	bool m_hasUpdated;
+	bool m_enabled;
 	mutable CcpMutex m_mutex;
 
 	std::chrono::steady_clock::time_point m_lastUpdateTime;

--- a/src/AudObstructionOcclusion.h
+++ b/src/AudObstructionOcclusion.h
@@ -2,7 +2,7 @@
 //
 // Creator: Phevos Rinis
 // Creation Date: Jul 2026
-// Copyright (c) 2026 CCP Games
+// Copyright (c) 2026 Fernis Creations
 //
 
 #pragma once

--- a/src/AudObstructionOcclusion.h
+++ b/src/AudObstructionOcclusion.h
@@ -69,7 +69,7 @@ public:
 	/// Forgets every emitter and the fade clock, for when audio is disabled.
 	void Reset();
 
-	/// Fades every tracked emitter back to clear and keeps them around until they get there.
+	/// Fades every tracked emitter back to clear.
 	void ClearAll();
 
 	/**
@@ -95,6 +95,7 @@ private:
 		void SetTarget(float target);
 		bool Advance(float deltaSeconds, float fadeRate);
 		bool ReachedTarget() const { return currentValue == targetValue; };
+		void SnapToTarget() { currentValue = targetValue; };
 	};
 
 	/// Everything we keep for one blocked emitter.

--- a/tests/python/audiotests/test/test_audgameobj_enabled_exposure.py
+++ b/tests/python/audiotests/test/test_audgameobj_enabled_exposure.py
@@ -8,7 +8,7 @@ from audiotests.base_test_class import (
     NONESSENTIAL_BNK, NONESSENTIAL_BNK_EVENT, NONESSENTIAL_STREAM_BNK, NONESSENTIAL_STREAM_EVENT
 )
 from audiotests.base_test_class import BaseAudio2TestClass
-from audiotests.utils import PumpOSWithTimeout
+from audiotests.utils import WaitForEmitterToWake, WaitForSoundBanksToLoad
 
 
 
@@ -31,8 +31,14 @@ class TestEnabledAudGameObjExposure(BaseAudio2TestClass):
 
         self.listener = audio2.GetListener()
         self.listener.SetPosition((0,0,0), (0,0,0), (0,0,0))
-        PumpOSWithTimeout(self.alwaysTrueBoolean, maxTries=3)
-        
+        self.assertTrue(
+            WaitForSoundBanksToLoad([
+                LOOP_EVENT, ONE_SHOT_EVENT, ESSENTIAL_EVENT, NONESSENTIAL_BNK_EVENT, NONESSENTIAL_STREAM_EVENT
+            ]),
+            "Timed out waiting for the test SoundBanks to load."
+        )
+        self.assertTrue(WaitForEmitterToWake(self.emitter), "Timed out waiting for the emitter to be woken up.")
+
     def tearDown(self):
         self.emitter.eventPrefix = ""
         self.emitter.StopAll()
@@ -266,14 +272,7 @@ class TestEnabledAudGameObjExposure(BaseAudio2TestClass):
 
     def test_audgameobjresource_sanitizes_events(self):
         def assert_event_sanitized(event_name):
-            playingID = self.emitter.SendEvent(event_name)
-            tries = 0
-            while playingID <= 0 and tries < 5:
-                blue.pyos.synchro.SleepWallclock(100)
-                blue.os.Pump()
-                playingID = self.emitter.SendEvent(event_name)
-                tries += 1
-            self.assertTrue(playingID > 0)
+            self.assertTrue(self.emitter.SendEvent(event_name) > 0)
 
         assert_event_sanitized(" {}".format(ONE_SHOT_EVENT))
         assert_event_sanitized("{} ".format(ONE_SHOT_EVENT))

--- a/tests/python/audiotests/test/test_audgameobj_enabled_exposure.py
+++ b/tests/python/audiotests/test/test_audgameobj_enabled_exposure.py
@@ -32,7 +32,7 @@ class TestEnabledAudGameObjExposure(BaseAudio2TestClass):
         self.listener = audio2.GetListener()
         self.listener.SetPosition((0,0,0), (0,0,0), (0,0,0))
         PumpOSWithTimeout(self.alwaysTrueBoolean, maxTries=3)
-
+        
     def tearDown(self):
         self.emitter.eventPrefix = ""
         self.emitter.StopAll()
@@ -265,23 +265,26 @@ class TestEnabledAudGameObjExposure(BaseAudio2TestClass):
 
 
     def test_audgameobjresource_sanitizes_events(self):
-        def assert_event_sanitized(event_name):
-            playingID = self.emitter.SendEvent(event_name)
-            tries = 0
-            while playingID <= 0 and tries < 5:
-                blue.pyos.synchro.SleepWallclock(100)
-                blue.os.Pump()
-                playingID = self.emitter.SendEvent(event_name)
-                tries += 1
+        def check_playing_id(playingID):
             self.assertTrue(playingID > 0)
 
-        assert_event_sanitized(" {}".format(ONE_SHOT_EVENT))
-        assert_event_sanitized("{} ".format(ONE_SHOT_EVENT))
-        assert_event_sanitized(" {} ".format(ONE_SHOT_EVENT))
-        assert_event_sanitized(" {}\n  \t  \r".format(ONE_SHOT_EVENT))
-        assert_event_sanitized("\n\n\n\n\n\n{}\n\n\n\n\n".format(ONE_SHOT_EVENT))
+        playingID = self.emitter.SendEvent(" {}".format(ONE_SHOT_EVENT))
+        self.wait_for_audio_condition(check_playing_id, playingID)
+
+        playingID = self.emitter.SendEvent("{} ".format(ONE_SHOT_EVENT))
+        self.wait_for_audio_condition(check_playing_id, playingID)
+
+        playingID = self.emitter.SendEvent(" {} ".format(ONE_SHOT_EVENT))
+        self.wait_for_audio_condition(check_playing_id, playingID)
+
+        playingID = self.emitter.SendEvent(" {}\n  \t  \r".format(ONE_SHOT_EVENT))
+        self.wait_for_audio_condition(check_playing_id, playingID)
+
+        playingID = self.emitter.SendEvent("\n\n\n\n\n\n{}\n\n\n\n\n".format(ONE_SHOT_EVENT))
+        self.wait_for_audio_condition(check_playing_id, playingID)
 
         # Test with event prefixes
         prefix = ONE_SHOT_EVENT[:5]
-        self.emitter.eventPrefix = prefix
-        assert_event_sanitized(" {}\n".format(ONE_SHOT_EVENT[5:]))
+        self.emitter.eventPrefix = prefix 
+        playingID = self.emitter.SendEvent(" {}\n".format(ONE_SHOT_EVENT[5:]))
+        self.wait_for_audio_condition(check_playing_id, playingID)

--- a/tests/python/audiotests/test/test_audgameobj_enabled_exposure.py
+++ b/tests/python/audiotests/test/test_audgameobj_enabled_exposure.py
@@ -265,7 +265,7 @@ class TestEnabledAudGameObjExposure(BaseAudio2TestClass):
 
 
     def test_audgameobjresource_sanitizes_events(self):
-        def assert_event_sanitized(event_name)
+        def assert_event_sanitized(event_name):
             playingID = self.emitter.SendEvent(event_name)
             tries = 0
             while playingID <= 0 and tries < 5:

--- a/tests/python/audiotests/test/test_audgameobj_enabled_exposure.py
+++ b/tests/python/audiotests/test/test_audgameobj_enabled_exposure.py
@@ -32,7 +32,7 @@ class TestEnabledAudGameObjExposure(BaseAudio2TestClass):
         self.listener = audio2.GetListener()
         self.listener.SetPosition((0,0,0), (0,0,0), (0,0,0))
         PumpOSWithTimeout(self.alwaysTrueBoolean, maxTries=3)
-        
+
     def tearDown(self):
         self.emitter.eventPrefix = ""
         self.emitter.StopAll()
@@ -281,10 +281,7 @@ class TestEnabledAudGameObjExposure(BaseAudio2TestClass):
         assert_event_sanitized(" {}\n  \t  \r".format(ONE_SHOT_EVENT))
         assert_event_sanitized("\n\n\n\n\n\n{}\n\n\n\n\n".format(ONE_SHOT_EVENT))
 
-        playingID = self.emitter.SendEvent("\n\n\n\n\n\n{}\n\n\n\n\n".format(ONE_SHOT_EVENT))
-        self.wait_for_audio_condition(check_playing_id, playingID)
-
         # Test with event prefixes
         prefix = ONE_SHOT_EVENT[:5]
-        self.emitter.eventPrefix = prefix 
+        self.emitter.eventPrefix = prefix
         assert_event_sanitized(" {}\n".format(ONE_SHOT_EVENT[5:]))

--- a/tests/python/audiotests/test/test_audgameobj_enabled_exposure.py
+++ b/tests/python/audiotests/test/test_audgameobj_enabled_exposure.py
@@ -265,20 +265,21 @@ class TestEnabledAudGameObjExposure(BaseAudio2TestClass):
 
 
     def test_audgameobjresource_sanitizes_events(self):
-        def check_playing_id(playingID):
+        def assert_event_sanitized(event_name)
+            playingID = self.emitter.SendEvent(event_name)
+            tries = 0
+            while playingID <= 0 and tries < 5:
+                blue.pyos.synchro.SleepWallclock(100)
+                blue.os.Pump()
+                playingID = self.emitter.SendEvent(event_name)
+                tries += 1
             self.assertTrue(playingID > 0)
 
-        playingID = self.emitter.SendEvent(" {}".format(ONE_SHOT_EVENT))
-        self.wait_for_audio_condition(check_playing_id, playingID)
-
-        playingID = self.emitter.SendEvent("{} ".format(ONE_SHOT_EVENT))
-        self.wait_for_audio_condition(check_playing_id, playingID)
-
-        playingID = self.emitter.SendEvent(" {} ".format(ONE_SHOT_EVENT))
-        self.wait_for_audio_condition(check_playing_id, playingID)
-
-        playingID = self.emitter.SendEvent(" {}\n  \t  \r".format(ONE_SHOT_EVENT))
-        self.wait_for_audio_condition(check_playing_id, playingID)
+        assert_event_sanitized(" {}".format(ONE_SHOT_EVENT))
+        assert_event_sanitized("{} ".format(ONE_SHOT_EVENT))
+        assert_event_sanitized(" {} ".format(ONE_SHOT_EVENT))
+        assert_event_sanitized(" {}\n  \t  \r".format(ONE_SHOT_EVENT))
+        assert_event_sanitized("\n\n\n\n\n\n{}\n\n\n\n\n".format(ONE_SHOT_EVENT))
 
         playingID = self.emitter.SendEvent("\n\n\n\n\n\n{}\n\n\n\n\n".format(ONE_SHOT_EVENT))
         self.wait_for_audio_condition(check_playing_id, playingID)
@@ -286,5 +287,4 @@ class TestEnabledAudGameObjExposure(BaseAudio2TestClass):
         # Test with event prefixes
         prefix = ONE_SHOT_EVENT[:5]
         self.emitter.eventPrefix = prefix 
-        playingID = self.emitter.SendEvent(" {}\n".format(ONE_SHOT_EVENT[5:]))
-        self.wait_for_audio_condition(check_playing_id, playingID)
+        assert_event_sanitized(" {}\n".format(ONE_SHOT_EVENT[5:]))

--- a/tests/python/audiotests/test/test_audmanager_exposure.py
+++ b/tests/python/audiotests/test/test_audmanager_exposure.py
@@ -8,7 +8,7 @@ import blue
 
 from audiotests.base_test_class import COMMON_BNK, LOOP_BNK, LOOP_EVENT, ONE_SHOT_BNK
 from audiotests.base_test_class import GetAudioMetadataFromFile
-from audiotests.utils import PumpOSWithTimeout
+from audiotests.utils import PumpOSWithTimeout, WaitForSoundBanksToLoad
 
 class TestAudManagerExposure(unittest.TestCase):
     @classmethod
@@ -143,11 +143,11 @@ class TestAudManagerExposure(unittest.TestCase):
         import audio2
         self.audioManager.LoadBank(COMMON_BNK)
         self.audioManager.LoadBank(LOOP_BNK)
-        PumpOSWithTimeout(self.alwaysTrueBoolean, maxTries=3)
+        self.assertTrue(WaitForSoundBanksToLoad([LOOP_EVENT]), "Timed out waiting for the test SoundBanks to load.")
         emitter1 = audio2.AudEmitter("emitter1")
         emitter2 = audio2.AudEmitter("emitter2")
 
-        self.assertTrue(emitter1.SendEvent(LOOP_EVENT) > 0) 
+        self.assertTrue(emitter1.SendEvent(LOOP_EVENT) > 0)
         self.assertTrue(emitter2.SendEvent(LOOP_EVENT) > 0)
 
         self.audioManager.StopAll()

--- a/tests/python/audiotests/test/test_auduiplayer_exposure.py
+++ b/tests/python/audiotests/test/test_auduiplayer_exposure.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 from audiotests.base_test_class import COMMON_BNK, LOOP_BNK, LOOP_EVENT, ONE_SHOT_BNK, ONE_SHOT_EVENT
 from audiotests.base_test_class import BaseAudio2TestClass
-from audiotests.utils import PumpOSWithTimeout
+from audiotests.utils import PumpOSWithTimeout, WaitForEmitterToWake, WaitForSoundBanksToLoad
 
 
 class TestAudUIPlayerExposure(BaseAudio2TestClass):
@@ -14,8 +14,15 @@ class TestAudUIPlayerExposure(BaseAudio2TestClass):
         cls.Initialize(cls, defaultSoundBanks=[COMMON_BNK, LOOP_BNK, ONE_SHOT_BNK])
 
     def setUp(self):
+        import audio2
         self.audioManager.Enable()
-        PumpOSWithTimeout(self.alwaysTrueBoolean, maxTries=3)
+        uiPlayer = audio2.GetUIPlayer()
+        uiPlayer.SetPlacement((0,0,0), (0,0,0), (0,0,0))
+        self.assertTrue(
+            WaitForSoundBanksToLoad([LOOP_EVENT, ONE_SHOT_EVENT]),
+            "Timed out waiting for the test SoundBanks to load."
+        )
+        self.assertTrue(WaitForEmitterToWake(uiPlayer), "Timed out waiting for the UI player to be woken up.")
 
     def tearDown(self):
         self.audioManager.Disable()

--- a/tests/python/audiotests/test/test_obstruction_occlusion_exposure.py
+++ b/tests/python/audiotests/test/test_obstruction_occlusion_exposure.py
@@ -44,7 +44,37 @@ class TestObstructionOcclusionExposure(BaseAudio2TestClass):
     def SetBlockage(self, blockage):
         return self.manager.SetEmitterLineOfSightBlockage(self.emitter.ID, blockage)
 
+    def EstablishClear(self):
+        self.assertTrue(self.SetBlockage(0.0))
+        self.Pump()
+
+    def test_a_first_value_is_applied_at_once(self):
+        self.manager.obstructionOcclusionFadeRate = SLOW_FADE_RATE
+
+        self.assertTrue(self.SetBlockage(1.0))
+        self.Pump()
+
+        self.assertEqual(self.GetOcclusion(), 1.0)
+
+    def test_an_emitter_that_is_back_to_clear_still_fades(self):
+        
+        self.manager.obstructionOcclusionFadeRate = INSTANT_FADE_RATE
+        self.assertTrue(self.SetBlockage(1.0))
+        self.Pump()
+        self.assertTrue(self.SetBlockage(0.0))
+        self.Pump()
+        self.assertEqual(self.GetOcclusion(), 0.0)
+
+        self.manager.obstructionOcclusionFadeRate = SLOW_FADE_RATE
+        self.assertTrue(self.SetBlockage(1.0))
+        self.Pump()
+
+        occlusion = self.GetOcclusion()
+        self.assertGreater(occlusion, 0.0, "Occlusion never started fading back in.")
+        self.assertLess(occlusion, 1.0, "Occlusion jumped to its target instead of fading.")
+
     def test_occlusion_is_applied_immediately_at_a_zero_fade_rate(self):
+        self.EstablishClear()
         self.manager.obstructionOcclusionFadeRate = INSTANT_FADE_RATE
 
         self.assertTrue(self.SetBlockage(1.0))
@@ -54,6 +84,7 @@ class TestObstructionOcclusionExposure(BaseAudio2TestClass):
 
     def test_occlusion_fades_in_gradually(self):
         """The value has to interpolate towards its target rather than jumping straight to it."""
+        self.EstablishClear()
         self.manager.obstructionOcclusionFadeRate = SLOW_FADE_RATE
 
         self.assertTrue(self.SetBlockage(1.0))
@@ -85,6 +116,7 @@ class TestObstructionOcclusionExposure(BaseAudio2TestClass):
 
     def test_a_fade_settles_on_its_target_without_overshooting(self):
         """A single tick large enough to cover the whole fade must stop exactly on the target."""
+        self.EstablishClear()
         self.manager.obstructionOcclusionFadeRate = FAST_FADE_RATE
 
         self.assertTrue(self.SetBlockage(1.0))

--- a/tests/python/audiotests/test/test_obstruction_occlusion_exposure.py
+++ b/tests/python/audiotests/test/test_obstruction_occlusion_exposure.py
@@ -1,0 +1,176 @@
+# Copyright © 2026 CCP ehf.
+
+from audiotests.base_test_class import COMMON_BNK
+from audiotests.base_test_class import BaseAudio2TestClass
+from audiotests.utils import PumpOSWithTimeout
+
+
+INSTANT_FADE_RATE = 0.0
+SLOW_FADE_RATE = 0.01  
+FAST_FADE_RATE = 100.0 
+
+
+class TestObstructionOcclusionExposure(BaseAudio2TestClass):
+    """Tests line-of-sight occlusion, in particular the interpolation that produces the fade."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Initialize(cls, defaultSoundBanks=[COMMON_BNK])
+
+    def setUp(self):
+        import audio2
+        self.audioManager.Enable()
+        self.manager = self.audioManager.manager
+
+        self.emitter = audio2.AudEmitter("occlusionTestEmitter")
+        self.emitter.SetPlacement((0, 0, 0), (0, 0, 0), (0, 0, 0))
+
+        self.manager.obstructionOcclusionEnabled = True
+        self.manager.obstructionOcclusionFadeRate = INSTANT_FADE_RATE
+
+    def tearDown(self):
+        self.emitter = None
+        self.audioManager.Disable()
+
+    def Pump(self, times=3):
+        """Tick the engine. Each tick runs AudManager::Process(), which advances the occlusion fades.
+        """
+        PumpOSWithTimeout(self.alwaysTrueBoolean, maxTries=times)
+
+    def GetOcclusion(self):
+        return self.manager.GetEmitterOcclusion(self.emitter.ID)
+
+    def SetBlockage(self, blockage):
+        return self.manager.SetEmitterLineOfSightBlockage(self.emitter.ID, blockage)
+
+    def test_occlusion_is_applied_immediately_at_a_zero_fade_rate(self):
+        self.manager.obstructionOcclusionFadeRate = INSTANT_FADE_RATE
+
+        self.assertTrue(self.SetBlockage(1.0))
+        self.Pump()
+
+        self.assertEqual(self.GetOcclusion(), 1.0)
+
+    def test_occlusion_fades_in_gradually(self):
+        """The value has to interpolate towards its target rather than jumping straight to it."""
+        self.manager.obstructionOcclusionFadeRate = SLOW_FADE_RATE
+
+        self.assertTrue(self.SetBlockage(1.0))
+        self.Pump()
+        firstValue = self.GetOcclusion()
+        self.Pump()
+        secondValue = self.GetOcclusion()
+
+        self.assertGreater(firstValue, 0.0, "Occlusion never started fading in.")
+        self.assertGreater(secondValue, firstValue, "Occlusion stopped advancing towards its target.")
+        self.assertLess(secondValue, 1.0, "Occlusion jumped to its target instead of fading.")
+
+    def test_occlusion_fades_back_out_gradually(self):
+        self.manager.obstructionOcclusionFadeRate = INSTANT_FADE_RATE
+        self.assertTrue(self.SetBlockage(1.0))
+        self.Pump()
+        self.assertEqual(self.GetOcclusion(), 1.0)
+
+        self.manager.obstructionOcclusionFadeRate = SLOW_FADE_RATE
+        self.assertTrue(self.SetBlockage(0.0))
+        self.Pump()
+        firstValue = self.GetOcclusion()
+        self.Pump()
+        secondValue = self.GetOcclusion()
+
+        self.assertLess(firstValue, 1.0, "Occlusion never started fading out.")
+        self.assertLess(secondValue, firstValue, "Occlusion stopped advancing towards its target.")
+        self.assertGreater(secondValue, 0.0, "Occlusion jumped to its target instead of fading.")
+
+    def test_a_fade_settles_on_its_target_without_overshooting(self):
+        """A single tick large enough to cover the whole fade must stop exactly on the target."""
+        self.manager.obstructionOcclusionFadeRate = FAST_FADE_RATE
+
+        self.assertTrue(self.SetBlockage(1.0))
+        self.Pump()
+
+        self.assertEqual(self.GetOcclusion(), 1.0)
+
+    def test_a_fade_out_settles_on_its_target_without_undershooting(self):
+        self.manager.obstructionOcclusionFadeRate = INSTANT_FADE_RATE
+        self.assertTrue(self.SetBlockage(1.0))
+        self.Pump()
+
+        self.manager.obstructionOcclusionFadeRate = FAST_FADE_RATE
+        self.assertTrue(self.SetBlockage(0.0))
+        self.Pump()
+
+        self.assertEqual(self.GetOcclusion(), 0.0)
+
+    def test_blockage_is_clamped_to_a_valid_range(self):
+        self.manager.obstructionOcclusionFadeRate = INSTANT_FADE_RATE
+
+        self.assertTrue(self.SetBlockage(5.0))
+        self.Pump()
+        self.assertEqual(self.GetOcclusion(), 1.0)
+
+        self.assertTrue(self.SetBlockage(-1.0))
+        self.Pump()
+        self.assertEqual(self.GetOcclusion(), 0.0)
+
+    def test_a_negative_fade_rate_is_clamped_to_zero(self):
+        self.manager.obstructionOcclusionFadeRate = -5.0
+
+        self.assertEqual(self.manager.obstructionOcclusionFadeRate, 0.0)
+
+    def test_clearing_returns_every_emitter_to_clear(self):
+        self.manager.obstructionOcclusionFadeRate = INSTANT_FADE_RATE
+        self.assertTrue(self.SetBlockage(1.0))
+        self.Pump()
+        self.assertEqual(self.GetOcclusion(), 1.0)
+
+        self.manager.ClearObstructionOcclusion()
+        self.Pump()
+
+        self.assertEqual(self.GetOcclusion(), 0.0)
+
+    def test_disabling_clears_existing_values_and_rejects_new_ones(self):
+        self.manager.obstructionOcclusionFadeRate = INSTANT_FADE_RATE
+        self.assertTrue(self.SetBlockage(1.0))
+        self.Pump()
+        self.assertEqual(self.GetOcclusion(), 1.0)
+
+        self.manager.obstructionOcclusionEnabled = False
+        self.Pump()
+        self.assertEqual(self.GetOcclusion(), 0.0)
+
+        self.assertFalse(self.SetBlockage(1.0))
+        self.Pump()
+        self.assertEqual(self.GetOcclusion(), 0.0)
+
+    def test_blockage_is_rejected_for_an_emitter_that_does_not_exist(self):
+
+        unknownEmitterID = self.emitter.ID + 1000000
+
+        self.assertFalse(self.manager.SetEmitterLineOfSightBlockage(unknownEmitterID, 1.0))
+        self.assertEqual(self.manager.GetEmitterOcclusion(unknownEmitterID), 0.0)
+
+    def test_blockage_is_rejected_for_the_listener(self):
+        """Occlusion is measured relative to the listener, so occluding the listener is meaningless."""
+        import audio2
+        listenerID = audio2.GetListener().ID
+
+        self.assertFalse(self.manager.SetEmitterLineOfSightBlockage(listenerID, 1.0))
+        self.assertEqual(self.manager.GetEmitterOcclusion(listenerID), 0.0)
+
+    def test_occlusion_is_suppressed_while_acoustics_are_enabled(self):
+        """Acoustics transmission already attenuates, so occlusion must not stack on top of it."""
+        self.manager.spatialAudioGeometryEnabled = True
+        if not self.manager.spatialAudioGeometryEnabled:
+            self.skipTest("Spatial audio geometry is not available on this platform.")
+
+        try:
+            self.manager.obstructionOcclusionFadeRate = INSTANT_FADE_RATE
+
+            self.assertTrue(self.SetBlockage(1.0))
+            self.Pump()
+
+            self.assertEqual(self.GetOcclusion(), 0.0)
+        finally:
+            self.manager.spatialAudioGeometryEnabled = False

--- a/tests/python/audiotests/test/test_python_audiomanager.py
+++ b/tests/python/audiotests/test/test_python_audiomanager.py
@@ -4,7 +4,7 @@ import unittest
 
 from audiotests.base_test_class import COMMON_BNK, LOOP_BNK, LOOP_EVENT, ONE_SHOT_BNK, ONE_SHOT_EVENT, SOUNDBANK_FILEPATH
 from audiotests.base_test_class import BaseAudio2TestClass
-from audiotests.utils import GetAudioMetadataFromFile, PumpOSWithTimeout
+from audiotests.utils import GetAudioMetadataFromFile, PumpOSWithTimeout, WaitForEmitterToWake, WaitForSoundBanksToLoad
 
 class TestPythonAudioManager(BaseAudio2TestClass):
     @classmethod
@@ -68,7 +68,8 @@ class TestPythonAudioManager(BaseAudio2TestClass):
         emitter.SetPlacement((0,0,0), (0,0,0), (0,0,0))
         listener = audio2.GetListener()
         listener.SetPosition((0,0,0), (0,0,0), (0,0,0))
-        PumpOSWithTimeout(self.alwaysTrueBoolean, maxTries=3)
+        self.assertTrue(WaitForSoundBanksToLoad([LOOP_EVENT]), "Timed out waiting for the test SoundBanks to load.")
+        self.assertTrue(WaitForEmitterToWake(emitter), "Timed out waiting for the emitter to be woken up.")
         playingID = emitter.SendEvent(LOOP_EVENT)
         self.assertTrue(playingID > 0)
         emitter.StopAll()
@@ -83,7 +84,8 @@ class TestPythonAudioManager(BaseAudio2TestClass):
         emitter.SetPlacement((0,0,0), (0,0,0), (0,0,0))
         listener = audio2.GetListener()
         listener.SetPosition((0,0,0), (0,0,0), (0,0,0))
-        PumpOSWithTimeout(self.alwaysTrueBoolean, maxTries=3)
+        self.assertTrue(WaitForSoundBanksToLoad([LOOP_EVENT]), "Timed out waiting for the test SoundBanks to load.")
+        self.assertTrue(WaitForEmitterToWake(emitter), "Timed out waiting for the emitter to be woken up.")
 
         playingID = emitter.SendEvent(LOOP_EVENT)
         self.assertTrue(playingID > 0)
@@ -110,7 +112,11 @@ class TestPythonAudioManager(BaseAudio2TestClass):
         emitter.SetPlacement((0,0,0), (0,0,0), (0,0,0))
         listener = audio2.GetListener()
         listener.SetPosition((0,0,0), (0,0,0), (0,0,0))
-        PumpOSWithTimeout(self.alwaysTrueBoolean, maxTries=3)
+        self.assertTrue(
+            WaitForSoundBanksToLoad([LOOP_EVENT, ONE_SHOT_EVENT]),
+            "Timed out waiting for the test SoundBanks to load."
+        )
+        self.assertTrue(WaitForEmitterToWake(emitter), "Timed out waiting for the emitter to be woken up.")
 
         loopPlayingID = emitter.SendEvent(LOOP_EVENT)
         self.assertTrue(loopPlayingID > 0)

--- a/tests/python/audiotests/utils.py
+++ b/tests/python/audiotests/utils.py
@@ -15,6 +15,24 @@ def PumpOSWithTimeout(booleanFunc, maxTries=10):
         numTries += 1
     return not booleanFunc()
 
+def WaitForSoundBanksToLoad(events, maxTries=20):
+    """Pump until every given event can be posted, which means its SoundBank has finished loading.
+    SoundBanks are loaded asynchronously so SendEvent returns 0 until the load callback has been hit.
+    """
+    import audio2
+    probe = audio2.AudEmitter("soundBankLoadProbe")
+    probe.SetPlacement((0,0,0), (0,0,0), (0,0,0))
+    allLoaded = True
+    for event in events:
+        if not PumpOSWithTimeout(lambda event=event: probe.SendEvent(event) <= 0, maxTries=maxTries):
+            allLoaded = False
+    probe.StopAll()
+    return allLoaded
+
+def WaitForEmitterToWake(emitter, maxTries=10):
+    """Pump until sound prioritization has woken the emitter. Culled emitters queue events instead of posting them."""
+    return PumpOSWithTimeout(emitter.IsCulled, maxTries=maxTries)
+
 def GetAudioMetadataFromFile():
     """Gets audio metadata from file and returns it as a dict. Also converts eventIDs to int in the process."""
     with open(AUDIO_METADATA_FILEPATH, "r") as f:

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "dependencies": [
     {
       "name": "carbon-blue",
-      "version>=": "6.0.0"
+      "version>=": "5.1.2"
     },
     {
       "name": "carbon-math",
@@ -27,10 +27,6 @@
       "name": "carbon-exefile",
       "version>=": "4.1.1",
       "host": true
-    },
-    {
-      "name": "carbon-core",
-      "version>=": "3.0.1"
     }
   ],
   "overrides": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "dependencies": [
     {
       "name": "carbon-blue",
-      "version>=": "5.1.2"
+      "version>=": "6.0.0"
     },
     {
       "name": "carbon-math",
@@ -27,6 +27,10 @@
       "name": "carbon-exefile",
       "version>=": "4.1.1",
       "host": true
+    },
+    {
+      "name": "carbon-core",
+      "version>=": "3.0.1"
     }
   ],
   "overrides": [


### PR DESCRIPTION
## Description

This PR implements basic occlusion/obstruction using LPF and implementing [SetObjectObstructionAndOcclusion()](https://www.audiokinetic.com/en/public-library/2025.1.9_9197/?source=SDK&id=namespace_a_k_1_1_sound_engine_a1b3e18a25b405e55ba82de9b70cd11ba.html) from the Wwise API.

In addition to that it manages emitterIDs that are occluded/passthrough and handle fade in/out internals.
This implementation differs from the Acoustics API in the sense that it completely relies on Carbon's (destiny) line-of-sight ray tracing checks to know what is occluded and what not.

The whole path end to end in short is the following: Destiny → Python → trinity → CarbonAudio → Wwise.

## Technical details: 

- New class `AudObstructionOcclusion` : Owns all per emitter obstruction/occlusion and talks to the wwise API. We store the emitter IDs and states in a unordered map and handle their states, in addition we also handle fade/in out intervals
- The class has no concept of the actual emitter states so it reads that from AudManager 
- It's also important to note that currently we disable basic occlusion/obstruction when acoustics are ON to avoid attenuation stacking (e.g -12dB occlusion + -12 dB tranmission = -24dB reduction which is unexpected ). This will potentially change with the introduction of trigger volumes and we will keep both systems alive.


## Lifecycle 

- Update loop : AudManager::Process(), once per tick, before RenderAudio()): advances all fades using a clock delta and sends only changed values to Wwise.
- Emitter validation : values are only accepted/tracked for emitters that actually exist, see `WithCallbackGameObject`
- Culling : emitters that are currently culled are skipped but keep fading
- Cleanup : entries that fade fully back to unblocked are dropped to keep the map small , see `UnregisterGameObject() `

## Testing
Tested and implemented for EVE Frontier.