### PR TITLE
Make a cleaner API for occlusion from Python

### DIFF
--- a/python/audio2/audiomanager.py
+++ b/python/audio2/audiomanager.py
@@ -2,6 +2,8 @@
 
 import audio2
 
+from audio2.occlusion import OcclusionManager
+
 INIT_BANK = "Init.bnk"
 AUDIO_STATE_UNINITIALIZED = 0
 AUDIO_STATE_DISABLED = 1
@@ -35,6 +37,7 @@ class AudioManager(object):
         """
         self.defaultSoundBanks = []
         self.manager = audio2.GetOrCreateManager()
+        self.occlusion = OcclusionManager(self.manager)
         self.staticDataRepository = audio2.GetStaticDataRepository()
         self.banksWaitingToLoad = set()
 

--- a/python/audio2/occlusion.py
+++ b/python/audio2/occlusion.py
@@ -1,0 +1,63 @@
+# Copyright © 2026 CCP ehf.
+
+
+class OcclusionManager(object):
+    """Wrapper for Carbon Audio's line-of-sight obstruction/occlusion API.
+
+    The game runs its own sightline queries and feeds per-emitter blockage values in here.
+    Carbon Audio fades the applied occlusion towards each emitter's latest value and never
+    times values out, so keeping feeds fresh is the caller's responsibility.
+
+    Reached through AudioManager as audioManager.occlusion rather than constructed directly.
+    """
+
+    def __init__(self, manager):
+        """
+        :param manager: The raw Carbon Audio manager whose occlusion API this wraps.
+        """
+        self._manager = manager
+
+    @property
+    def enabled(self):
+        """Whether game-driven obstruction/occlusion processing is enabled. Disabling fades all values back to clear."""
+        return self._manager.obstructionOcclusionEnabled
+
+    @enabled.setter
+    def enabled(self, value):
+        self._manager.obstructionOcclusionEnabled = value
+
+    @property
+    def fadeRate(self):
+        """How fast obstruction/occlusion values fade towards their targets, in units per second. 0 = instantaneous."""
+        return self._manager.obstructionOcclusionFadeRate
+
+    @fadeRate.setter
+    def fadeRate(self, value):
+        self._manager.obstructionOcclusionFadeRate = value
+
+    def ClearAll(self):
+        """Fade the occlusion values of all tracked emitters back to clear."""
+        self._manager.ClearObstructionOcclusion()
+
+    def GetEmitterOcclusion(self, emitterID):
+        """Get the occlusion value currently applied to an emitter.
+
+        :param emitterID: The ID of the emitter to query.
+        :type emitterID: int
+        :return: The emitter's current occlusion value, or 0.0 if the emitter is clear or is not being tracked.
+        """
+        return self._manager.GetEmitterOcclusion(emitterID)
+
+    def SetEmitterLineOfSightBlockage(self, emitterID, blockage):
+        """Set a line-of-sight blockage ratio for an emitter.
+
+        The applied occlusion fades towards this value at fadeRate.
+
+        :param emitterID: The ID of the emitter the blockage applies to.
+        :type emitterID: int
+        :param blockage: How blocked the line of sight between the listener and the emitter is,
+                         from 0.0 (clear) to 1.0 (fully blocked).
+        :type blockage: float
+        :return: True if the emitter exists, otherwise False.
+        """
+        return self._manager.SetEmitterLineOfSightBlockage(emitterID, blockage)

--- a/tests/python/audiotests/test/test_python_audiomanager.py
+++ b/tests/python/audiotests/test/test_python_audiomanager.py
@@ -207,6 +207,28 @@ class TestPythonAudioManager(BaseAudio2TestClass):
         PumpOSWithTimeout(self.alwaysTrueBoolean, maxTries=3)
         self.assertEqual(self.audioManager.GetLoadedSoundBanks(), [INIT_BANK])
 
+    def test_occlusion_is_reachable_without_the_raw_manager(self):
+        """The occlusion sub-object covers the whole occlusion API so callers never need .manager."""
+        import audio2
+
+        occlusion = self.audioManager.occlusion
+        occlusion.enabled = True
+        self.assertTrue(occlusion.enabled)
+
+        occlusion.fadeRate = 0.0
+        self.assertEqual(occlusion.fadeRate, 0.0)
+
+        emitter = audio2.AudEmitter("wrapperOcclusionEmitter")
+        emitter.SetPlacement((0, 0, 0), (0, 0, 0), (0, 0, 0))
+
+        self.assertTrue(occlusion.SetEmitterLineOfSightBlockage(emitter.ID, 1.0))
+        PumpOSWithTimeout(self.alwaysTrueBoolean, maxTries=3)
+        self.assertEqual(occlusion.GetEmitterOcclusion(emitter.ID), 1.0)
+
+        occlusion.ClearAll()
+        PumpOSWithTimeout(self.alwaysTrueBoolean, maxTries=3)
+        self.assertEqual(occlusion.GetEmitterOcclusion(emitter.ID), 0.0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
In order for the client to be able to interact with our occlusion API it was necessary for it to reach down to the raw C++ audio manager (e.g. `GetAudioManager().manager`). This commit adds an actual API on the Python side that can be used instead.