### PR TITLE
Add HasUsableWorldPosition to audio emitters and expose position to Python

### DIFF
--- a/src/AudGameObjResource.cpp
+++ b/src/AudGameObjResource.cpp
@@ -45,7 +45,7 @@ AudGameObjResource::AudGameObjResource( IRoot* lockobj ) : PARENTLOCK( m_paramet
 														 m_additionalCullingWeight( 0.0f ),
 														 m_cumulativeWeight( 0.0f ),
 														 m_maxAttenuationRadiusSq( 0.0f ),
-														 m_hasReceivedPosition(false),
+														 m_hasReceivedPosition( false ),
 														 m_waitingOneShotInRange( std::pair( std::chrono::steady_clock::now(), L"" ) ),
 														 m_eventName(L"")
 {
@@ -84,7 +84,7 @@ AudGameObjResource::AudGameObjResource( AkGameObjectID gameObjID, IRoot* lockobj
 														 						   m_additionalCullingWeight( 0.0f ),
 																				   m_cumulativeWeight( 0.0f ),
 																				   m_maxAttenuationRadiusSq( 0.0f ),
-																				   m_hasReceivedPosition(false),
+																				   m_hasReceivedPosition( false ),
 																				   m_waitingOneShotInRange( std::pair( std::chrono::steady_clock::now(), L"" ) ),
 																				   m_eventName(L"")
 {
@@ -633,7 +633,12 @@ void AudGameObjResource::Wake()
 			return;	
 		}
 
-		if(!m_hasReceivedPosition) 
+		if( !m_hasReceivedPosition )
+		{
+			return;
+		}
+
+		if( !IsUsableWorldPosition( m_position ) )
 		{
 			return;
 		}
@@ -1057,6 +1062,11 @@ AkGameObjectID AudGameObjResource::GetID() const
 Vector3 AudGameObjResource::GetPosition() const 
 {
     return m_position;
+}
+
+bool AudGameObjResource::HasUsableWorldPosition() const
+{
+	return IsUsableWorldPosition( m_position );
 }
 
 Vector3 AudGameObjResource::GetFront() const

--- a/src/AudGameObjResource.h
+++ b/src/AudGameObjResource.h
@@ -76,6 +76,8 @@ public:
 	std::wstring GetEventName();
 	// Get the current position of this game object.
 	Vector3 GetPosition() const override;
+	// Whether this game object has a valid world position.
+	virtual bool HasUsableWorldPosition() const;
 	// Get the effective front vector sent to Wwise.
 	Vector3 GetFront() const;
 	// Get the effective top vector sent to Wwise.
@@ -170,6 +172,8 @@ protected:
 	bool m_forceCullingState;
 	// Signals whether this audio emitter is currently muted or not.
 	bool m_muted;
+	// Set once the game has pushed a real position via SetPosition. 
+	bool m_hasReceivedPosition;
 	// The distance of this game object from the listener.
 	float m_distanceSqFromListener;
 	// Any additional weight you want this game object to have in the culling system. Can be from 0.0 to infinity. The higher the value the less likely it is to be culled.
@@ -180,8 +184,6 @@ protected:
 	float m_scalingFactor;
 	// The max attenuation radius this game object has.
 	float m_maxAttenuationRadiusSq;
-
-	bool m_hasReceivedPosition;
 	// Events waiting to play on this game object when it wakes up from being culled.
 	std::set<std::wstring> m_eventsOnWake;
 	// Playing IDs that have been explicitly stopped but have not received their Wwise end callback yet.

--- a/src/AudGameObjResource_Blue.cpp
+++ b/src/AudGameObjResource_Blue.cpp
@@ -31,6 +31,7 @@ const Be::ClassInfo* AudGameObjResource::ExposeToBlue()
 		MAP_ATTRIBUTE( "distanceFromListener", m_distanceSqFromListener, "The distance of this game object from the listener.\n:jessica-hidden: True", Be::READ )
 		MAP_ATTRIBUTE( "forceCullingState", m_forceCullingState, "Whether this game object's culling state is currently forced and not automatically\n:jessica-hidden: True", Be::READ )
 		MAP_ATTRIBUTE( "eventName", m_eventName, "The audio event that you want played on this audio object when it is initially created", Be::READWRITE | Be::PERSIST | Be::NOTIFY )
+		MAP_ATTRIBUTE( "position", m_position, "The position of this game object as audio sees it.\n:jessica-hidden: True", Be::READ )
 
 		MAP_PROPERTY_READONLY
 		( 
@@ -169,6 +170,12 @@ const Be::ClassInfo* AudGameObjResource::ExposeToBlue()
 			IsMuted,
 			"Whether or not this game object is currently muted."
 		)
-			
+		MAP_METHOD_AND_WRAP
+		(
+			"HasUsableWorldPosition",
+			HasUsableWorldPosition,
+			"Whether this game object has a valid world position."
+		)
+
 	EXPOSURE_END()
 }

--- a/src/AudMusicPlayer.cpp
+++ b/src/AudMusicPlayer.cpp
@@ -13,3 +13,8 @@ AudMusicPlayer::AudMusicPlayer( IRoot* lockobj ) : AudEmitter( MUSIC_GAME_OBJ_ID
 AudMusicPlayer::~AudMusicPlayer()
 {
 }
+
+bool AudMusicPlayer::HasUsableWorldPosition() const
+{
+	return false;
+}

--- a/src/AudMusicPlayer.h
+++ b/src/AudMusicPlayer.h
@@ -10,6 +10,9 @@ public:
 	AudMusicPlayer( IRoot* lockobj = NULL );
 	~AudMusicPlayer();
 
+	// The music player is never spatialized and should not be considered for any calculations that depend on world position.
+	bool HasUsableWorldPosition() const override;
+
 	EXPOSE_TO_BLUE();
 };
 

--- a/src/AudUIPlayer.cpp
+++ b/src/AudUIPlayer.cpp
@@ -17,6 +17,11 @@ AudUIPlayer::~AudUIPlayer()
 {
 }
 
+bool AudUIPlayer::HasUsableWorldPosition() const
+{
+	return false;
+}
+
 // ---------------------------------------------------------------------------------------
 // Description:
 //   Sends an event that will trigger the callback defined on m_callback when finished playing.

--- a/src/AudUIPlayer.h
+++ b/src/AudUIPlayer.h
@@ -14,6 +14,9 @@ public:
 
 	EXPOSE_TO_BLUE();
 	
+	// The UI emitter is never spatialized and should not be considered for any calculations that depend on world position.
+	bool HasUsableWorldPosition() const override;
+
 	unsigned int SendEventWithCallback( const std:: wstring& name );
 	// Post an event meant for dialogue. Allows for getting the duration of the playing event.
 	unsigned int PostDialogueEvent( const std:: wstring& eventName );

--- a/src/Audio2.h
+++ b/src/Audio2.h
@@ -13,6 +13,8 @@
 
 #include "Vector3.h"
 
+#include <cmath>
+
 //Global setting constants
 const int UI_GAME_OBJ_ID = 2;
 const int MUSIC_GAME_OBJ_ID = 3;
@@ -22,6 +24,16 @@ const int START_GAME_OBJ_COUNT = 5;
 // Makes sure objects are initialized far away so you don't hear them when they spawn.
 // Game objects are culled by default so this value will never hit Wwise.
 const Vector3 WWISE_INIT_POSITION = Vector3(FLT_MAX, FLT_MAX, FLT_MAX);
+
+// Whether a position is a real world placement rather than initial position. 
+// Also defends against positions that are NaN or infinite.
+inline bool IsUsableWorldPosition( const Vector3& position )
+{
+	return std::isfinite( position.x ) && std::isfinite( position.y ) && std::isfinite( position.z )
+		&& !( position.x == WWISE_INIT_POSITION.x
+			&& position.y == WWISE_INIT_POSITION.y
+			&& position.z == WWISE_INIT_POSITION.z );
+}
 
 extern bool g_shuttingDown;
 extern bool g_debugDisplayAllEmitters;

--- a/tests/python/audiotests/test/test_audemitter_exposure.py
+++ b/tests/python/audiotests/test/test_audemitter_exposure.py
@@ -94,3 +94,44 @@ class TestAudEmitterExposure(BaseAudio2TestClass):
 
         self.assertFalse(hasattr(listener, "front"))
         self.assertFalse(hasattr(listener, "top"))
+
+    def test_emitter_has_no_usable_world_position_before_placement(self):
+        """A fresh emitter still sits at the spawn sentinel, which is not a usable world position."""
+        self.assertFalse(self.emitter.HasUsableWorldPosition())
+
+    def test_emitter_has_usable_world_position_after_placement(self):
+        self.emitter.SetPlacement((1, 0, 0), (0, 1, 0), (0, 50, 0))
+
+        self.assertTrue(self.emitter.HasUsableWorldPosition())
+        self.assertVectorAlmostEqual(self.emitter.position, (0, 50, 0))
+
+    def test_emitter_at_origin_has_usable_world_position(self):
+        """(0, 0, 0) is a legitimate world position, not a sentinel."""
+        self.emitter.SetPlacement((1, 0, 0), (0, 1, 0), (0, 0, 0))
+
+        self.assertTrue(self.emitter.HasUsableWorldPosition())
+
+    def test_emitter_with_non_finite_position_has_no_usable_world_position(self):
+        self.emitter.SetPlacement((1, 0, 0), (0, 1, 0), (0, float("nan"), 0))
+
+        self.assertFalse(self.emitter.HasUsableWorldPosition())
+
+    def test_listener_has_usable_world_position_after_placement(self):
+        import audio2
+        listener = audio2.GetListener()
+        listener.SetPosition((1, 0, 0), (0, 1, 0), (10, 20, 30))
+
+        self.assertTrue(listener.HasUsableWorldPosition())
+        self.assertVectorAlmostEqual(listener.position, (10, 20, 30))
+
+    def test_ui_and_music_players_never_have_usable_world_position(self):
+        """UI and music game objects get a position for Wwise's sake but are not placed in the world,
+        so world-space systems such as line-of-sight must ignore them."""
+        import audio2
+        uiPlayer = audio2.GetUIPlayer()
+        musicPlayer = audio2.GetMusicPlayer()
+        uiPlayer.SetPlacement((1, 0, 0), (0, 1, 0), (0, 0, 0))
+        musicPlayer.SetPlacement((1, 0, 0), (0, 1, 0), (0, 0, 0))
+
+        self.assertFalse(uiPlayer.HasUsableWorldPosition())
+        self.assertFalse(musicPlayer.HasUsableWorldPosition())


### PR DESCRIPTION
This pull request is in the context of a larger whole. That whole being audio occlusion through Destiny. In order for the Python client to be able to feed positional info to Destiny to check line of sight, it was necessary to create HasUsableWorldPosition as well as exposing an audio emitter's position:
* HasUsableWorldPosition allows Python to not send garbage or huge distances to Destiny.
* Exposing `position` allows the client to feed an audio emitter's position to Destiny.

This has been tested on a Frontier sandbox.