### PR TITLE
Expose API to only retrieve currently awake emitters

### DIFF
--- a/python/audio2/audiomanager.py
+++ b/python/audio2/audiomanager.py
@@ -113,6 +113,13 @@ class AudioManager(object):
         """
         return self.manager.GetPrioritizedEmitters()
 
+    def GetAwakeEmitters(self):
+        """
+        Returns a list of audio emitter objects that are currently awake (not culled)
+        in the sound prioritization system.
+        """
+        return self.manager.GetAwakeEmitters()
+
     def Initialize(self, audioMetadata, defaultSoundBanks=[]):
         """Initialize the audio manager so that is ready to be enabled.
 

--- a/src/AudGameObjResource.cpp
+++ b/src/AudGameObjResource.cpp
@@ -45,7 +45,7 @@ AudGameObjResource::AudGameObjResource( IRoot* lockobj ) : PARENTLOCK( m_paramet
 														 m_additionalCullingWeight( 0.0f ),
 														 m_cumulativeWeight( 0.0f ),
 														 m_maxAttenuationRadiusSq( 0.0f ),
-														 m_hasReceivedPosition(false),
+														 m_hasReceivedPosition( false ),
 														 m_waitingOneShotInRange( std::pair( std::chrono::steady_clock::now(), L"" ) ),
 														 m_eventName(L"")
 {
@@ -84,7 +84,7 @@ AudGameObjResource::AudGameObjResource( AkGameObjectID gameObjID, IRoot* lockobj
 														 						   m_additionalCullingWeight( 0.0f ),
 																				   m_cumulativeWeight( 0.0f ),
 																				   m_maxAttenuationRadiusSq( 0.0f ),
-																				   m_hasReceivedPosition(false),
+																				   m_hasReceivedPosition( false ),
 																				   m_waitingOneShotInRange( std::pair( std::chrono::steady_clock::now(), L"" ) ),
 																				   m_eventName(L"")
 {
@@ -633,7 +633,12 @@ void AudGameObjResource::Wake()
 			return;	
 		}
 
-		if(!m_hasReceivedPosition) 
+		if( !m_hasReceivedPosition )
+		{
+			return;
+		}
+
+		if( !IsUsableWorldPosition( m_position ) )
 		{
 			return;
 		}
@@ -1057,6 +1062,11 @@ AkGameObjectID AudGameObjResource::GetID() const
 Vector3 AudGameObjResource::GetPosition() const 
 {
     return m_position;
+}
+
+bool AudGameObjResource::HasUsableWorldPosition() const
+{
+	return IsUsableWorldPosition( m_position );
 }
 
 Vector3 AudGameObjResource::GetFront() const

--- a/src/AudGameObjResource.h
+++ b/src/AudGameObjResource.h
@@ -76,6 +76,8 @@ public:
 	std::wstring GetEventName();
 	// Get the current position of this game object.
 	Vector3 GetPosition() const override;
+	// Whether this game object has a valid world position.
+	virtual bool HasUsableWorldPosition() const;
 	// Get the effective front vector sent to Wwise.
 	Vector3 GetFront() const;
 	// Get the effective top vector sent to Wwise.
@@ -170,6 +172,8 @@ protected:
 	bool m_forceCullingState;
 	// Signals whether this audio emitter is currently muted or not.
 	bool m_muted;
+	// Set once the game has pushed a real position via SetPosition. 
+	bool m_hasReceivedPosition;
 	// The distance of this game object from the listener.
 	float m_distanceSqFromListener;
 	// Any additional weight you want this game object to have in the culling system. Can be from 0.0 to infinity. The higher the value the less likely it is to be culled.
@@ -180,8 +184,6 @@ protected:
 	float m_scalingFactor;
 	// The max attenuation radius this game object has.
 	float m_maxAttenuationRadiusSq;
-
-	bool m_hasReceivedPosition;
 	// Events waiting to play on this game object when it wakes up from being culled.
 	std::set<std::wstring> m_eventsOnWake;
 	// Playing IDs that have been explicitly stopped but have not received their Wwise end callback yet.

--- a/src/AudGameObjResource_Blue.cpp
+++ b/src/AudGameObjResource_Blue.cpp
@@ -31,6 +31,7 @@ const Be::ClassInfo* AudGameObjResource::ExposeToBlue()
 		MAP_ATTRIBUTE( "distanceFromListener", m_distanceSqFromListener, "The distance of this game object from the listener.\n:jessica-hidden: True", Be::READ )
 		MAP_ATTRIBUTE( "forceCullingState", m_forceCullingState, "Whether this game object's culling state is currently forced and not automatically\n:jessica-hidden: True", Be::READ )
 		MAP_ATTRIBUTE( "eventName", m_eventName, "The audio event that you want played on this audio object when it is initially created", Be::READWRITE | Be::PERSIST | Be::NOTIFY )
+		MAP_ATTRIBUTE( "position", m_position, "The position of this game object as audio sees it.\n:jessica-hidden: True", Be::READ )
 
 		MAP_PROPERTY_READONLY
 		( 
@@ -169,6 +170,12 @@ const Be::ClassInfo* AudGameObjResource::ExposeToBlue()
 			IsMuted,
 			"Whether or not this game object is currently muted."
 		)
-			
+		MAP_METHOD_AND_WRAP
+		(
+			"HasUsableWorldPosition",
+			HasUsableWorldPosition,
+			"Whether this game object has a valid world position."
+		)
+
 	EXPOSURE_END()
 }

--- a/src/AudManager.cpp
+++ b/src/AudManager.cpp
@@ -1243,6 +1243,19 @@ std::vector<AudGameObjResource*> AudManager::GetPrioritizedAudioEmitters()
 	}
 	return result;
 }
+
+std::vector<AudGameObjResource*> AudManager::GetAwakeAudioEmitters()
+{
+	std::vector<AudGameObjResource*> result;
+	m_soundPrioritization->ForEachAwakeAudioObject( [&result]( IPrioritizedObject* obj )
+	{
+		if( !IsReservedGameObjectID( obj->GetID() ) )
+		{
+			result.push_back( static_cast<AudGameObjResource*>( obj ) );
+		}
+	} );
+	return result;
+}
 // Callback from Wwise to use for tracking performance of the sound engine. This is called when a timer stops. Only applicable in Profile or Debug Wwise flavors.
 void AudManager::AkPlatformProfilerPopTimer()
 {

--- a/src/AudManager.h
+++ b/src/AudManager.h
@@ -186,6 +186,8 @@ public:
 
 	// Debug
 	std::vector<AudGameObjResource*> GetPrioritizedAudioEmitters();
+	// Get the emitters that are currently awake (not culled) in the sound prioritization system. Built-in system objects (UI, music, listener) are excluded.
+	std::vector<AudGameObjResource*> GetAwakeAudioEmitters();
 #ifndef AK_OPTIMIZED
 	// Get the event name for the given playingID and emitter.
 	const std::wstring GetEventName( AkGameObjectID emitterID, AkPlayingID playingID );

--- a/src/AudManager_Blue.cpp
+++ b/src/AudManager_Blue.cpp
@@ -239,6 +239,12 @@ const Be::ClassInfo* AudManager::ExposeToBlue()
 		)
 		MAP_METHOD_AND_WRAP
 		(
+			"GetAwakeEmitters",
+			GetAwakeAudioEmitters,
+			"Exposes the audio emitters that are currently awake (not culled) in the sound prioritization system. Built-in system objects (UI, music, listener) are not included."
+		)
+		MAP_METHOD_AND_WRAP
+		(
 			"StartProfilerCapture",
 			StartProfilerCapture,
 			"Starts recording the sound engine profiling information into a file."

--- a/src/AudMusicPlayer.cpp
+++ b/src/AudMusicPlayer.cpp
@@ -13,3 +13,8 @@ AudMusicPlayer::AudMusicPlayer( IRoot* lockobj ) : AudEmitter( MUSIC_GAME_OBJ_ID
 AudMusicPlayer::~AudMusicPlayer()
 {
 }
+
+bool AudMusicPlayer::HasUsableWorldPosition() const
+{
+	return false;
+}

--- a/src/AudMusicPlayer.h
+++ b/src/AudMusicPlayer.h
@@ -10,6 +10,9 @@ public:
 	AudMusicPlayer( IRoot* lockobj = NULL );
 	~AudMusicPlayer();
 
+	// The music player is never spatialized and should not be considered for any calculations that depend on world position.
+	bool HasUsableWorldPosition() const override;
+
 	EXPOSE_TO_BLUE();
 };
 

--- a/src/AudUIPlayer.cpp
+++ b/src/AudUIPlayer.cpp
@@ -17,6 +17,11 @@ AudUIPlayer::~AudUIPlayer()
 {
 }
 
+bool AudUIPlayer::HasUsableWorldPosition() const
+{
+	return false;
+}
+
 // ---------------------------------------------------------------------------------------
 // Description:
 //   Sends an event that will trigger the callback defined on m_callback when finished playing.

--- a/src/AudUIPlayer.h
+++ b/src/AudUIPlayer.h
@@ -14,6 +14,9 @@ public:
 
 	EXPOSE_TO_BLUE();
 	
+	// The UI emitter is never spatialized and should not be considered for any calculations that depend on world position.
+	bool HasUsableWorldPosition() const override;
+
 	unsigned int SendEventWithCallback( const std:: wstring& name );
 	// Post an event meant for dialogue. Allows for getting the duration of the playing event.
 	unsigned int PostDialogueEvent( const std:: wstring& eventName );

--- a/src/Audio2.h
+++ b/src/Audio2.h
@@ -21,6 +21,11 @@ const int MUSIC_GAME_OBJ_ID = 3;
 const int LISTENER_GAME_OBJ_ID = 4;
 const int START_GAME_OBJ_COUNT = 5;
 
+inline bool IsReservedGameObjectID( AkGameObjectID id )
+{
+	return id < START_GAME_OBJ_COUNT;
+}
+
 // Makes sure objects are initialized far away so you don't hear them when they spawn.
 // Game objects are culled by default so this value will never hit Wwise.
 const Vector3 WWISE_INIT_POSITION = Vector3(FLT_MAX, FLT_MAX, FLT_MAX);

--- a/src/Audio2.h
+++ b/src/Audio2.h
@@ -13,6 +13,8 @@
 
 #include "Vector3.h"
 
+#include <cmath>
+
 //Global setting constants
 const int UI_GAME_OBJ_ID = 2;
 const int MUSIC_GAME_OBJ_ID = 3;
@@ -22,6 +24,16 @@ const int START_GAME_OBJ_COUNT = 5;
 // Makes sure objects are initialized far away so you don't hear them when they spawn.
 // Game objects are culled by default so this value will never hit Wwise.
 const Vector3 WWISE_INIT_POSITION = Vector3(FLT_MAX, FLT_MAX, FLT_MAX);
+
+// Whether a position is a real world placement rather than initial position. 
+// Also defends against positions that are NaN or infinite.
+inline bool IsUsableWorldPosition( const Vector3& position )
+{
+	return std::isfinite( position.x ) && std::isfinite( position.y ) && std::isfinite( position.z )
+		&& !( position.x == WWISE_INIT_POSITION.x
+			&& position.y == WWISE_INIT_POSITION.y
+			&& position.z == WWISE_INIT_POSITION.z );
+}
 
 extern bool g_shuttingDown;
 extern bool g_debugDisplayAllEmitters;

--- a/src/SoundPrioritization.h
+++ b/src/SoundPrioritization.h
@@ -256,6 +256,23 @@ public:
 
      const std::vector<IPrioritizedObject*>& GetPrioritizedAudioObjects() const;
 
+    /**
+     * @brief Visit every audio object that is currently awake (not culled).
+     * @param visitor Callable taking an IPrioritizedObject*
+     */
+    template<typename Visitor>
+    void ForEachAwakeAudioObject( Visitor&& visitor ) const
+    {
+        CcpAutoMutex mutex( m_objectsMutex );
+        for( auto obj : m_gameObjects )
+        {
+            if( !obj->IsCulled() )
+            {
+                visitor( obj );
+            }
+        }
+    }
+
 private:
 
     bool m_audioCullingEnabled;              /**< Current state of the culling system */

--- a/tests/python/audiotests/test/test_audemitter_exposure.py
+++ b/tests/python/audiotests/test/test_audemitter_exposure.py
@@ -94,3 +94,44 @@ class TestAudEmitterExposure(BaseAudio2TestClass):
 
         self.assertFalse(hasattr(listener, "front"))
         self.assertFalse(hasattr(listener, "top"))
+
+    def test_emitter_has_no_usable_world_position_before_placement(self):
+        """A fresh emitter still sits at the spawn sentinel, which is not a usable world position."""
+        self.assertFalse(self.emitter.HasUsableWorldPosition())
+
+    def test_emitter_has_usable_world_position_after_placement(self):
+        self.emitter.SetPlacement((1, 0, 0), (0, 1, 0), (0, 50, 0))
+
+        self.assertTrue(self.emitter.HasUsableWorldPosition())
+        self.assertVectorAlmostEqual(self.emitter.position, (0, 50, 0))
+
+    def test_emitter_at_origin_has_usable_world_position(self):
+        """(0, 0, 0) is a legitimate world position, not a sentinel."""
+        self.emitter.SetPlacement((1, 0, 0), (0, 1, 0), (0, 0, 0))
+
+        self.assertTrue(self.emitter.HasUsableWorldPosition())
+
+    def test_emitter_with_non_finite_position_has_no_usable_world_position(self):
+        self.emitter.SetPlacement((1, 0, 0), (0, 1, 0), (0, float("nan"), 0))
+
+        self.assertFalse(self.emitter.HasUsableWorldPosition())
+
+    def test_listener_has_usable_world_position_after_placement(self):
+        import audio2
+        listener = audio2.GetListener()
+        listener.SetPosition((1, 0, 0), (0, 1, 0), (10, 20, 30))
+
+        self.assertTrue(listener.HasUsableWorldPosition())
+        self.assertVectorAlmostEqual(listener.position, (10, 20, 30))
+
+    def test_ui_and_music_players_never_have_usable_world_position(self):
+        """UI and music game objects get a position for Wwise's sake but are not placed in the world,
+        so world-space systems such as line-of-sight must ignore them."""
+        import audio2
+        uiPlayer = audio2.GetUIPlayer()
+        musicPlayer = audio2.GetMusicPlayer()
+        uiPlayer.SetPlacement((1, 0, 0), (0, 1, 0), (0, 0, 0))
+        musicPlayer.SetPlacement((1, 0, 0), (0, 1, 0), (0, 0, 0))
+
+        self.assertFalse(uiPlayer.HasUsableWorldPosition())
+        self.assertFalse(musicPlayer.HasUsableWorldPosition())

--- a/tests/python/audiotests/test/test_awake_emitters_exposure.py
+++ b/tests/python/audiotests/test/test_awake_emitters_exposure.py
@@ -1,0 +1,91 @@
+# Copyright © 2026 CCP ehf.
+
+import blue
+
+from audiotests.base_test_class import BaseAudio2TestClass
+from audiotests.utils import PumpOSWithTimeout, WaitForEmitterToWake
+
+
+class TestAwakeEmittersExposure(BaseAudio2TestClass):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Initialize(cls)
+
+    def setUp(self):
+        import audio2
+        self.emitter = audio2.AudEmitter("awakeEmitter1")
+        self.emitter.SetPlacement((0,0,0), (0,0,0), (0,0,0))
+        self.audioManager.Enable()
+
+        self.listener = audio2.GetListener()
+        self.listener.SetPosition((0,0,0), (0,0,0), (0,0,0))
+        self.assertTrue(WaitForEmitterToWake(self.emitter), "Timed out waiting for the emitter to be woken up.")
+
+    def tearDown(self):
+        self.audioManager.manager.ResetCullingSettings()
+        self.audioManager.Disable()
+
+    def getAwakeEmitterNames(self):
+        return [emitter.name for emitter in self.audioManager.GetAwakeEmitters()]
+
+    def test_awake_emitters_contains_woken_emitter(self):
+        """A woken emitter shows up in GetAwakeEmitters and no returned emitter is culled."""
+        awakeEmitters = self.audioManager.GetAwakeEmitters()
+        self.assertIn("awakeEmitter1", [emitter.name for emitter in awakeEmitters])
+        for emitter in awakeEmitters:
+            self.assertFalse(emitter.IsCulled())
+
+    def test_awake_emitters_is_subset_of_prioritized_emitters(self):
+        """Every awake emitter is also in the full prioritized list."""
+        prioritizedNames = [emitter.name for emitter in self.audioManager.GetPrioritizedEmitters()]
+        for name in self.getAwakeEmitterNames():
+            self.assertIn(name, prioritizedNames)
+
+    def test_forced_culled_emitter_not_in_awake_emitters(self):
+        """An emitter forced into the culled state is excluded from GetAwakeEmitters."""
+        self.emitter.ForceCullingStateChange()
+        self.assertTrue(self.emitter.IsCulled())
+        self.assertNotIn("awakeEmitter1", self.getAwakeEmitterNames())
+
+        # Release the forced state and make sure it comes back.
+        self.emitter.ForceCullingStateChange()
+        self.assertTrue(WaitForEmitterToWake(self.emitter), "Timed out waiting for the emitter to be woken up again.")
+        self.assertIn("awakeEmitter1", self.getAwakeEmitterNames())
+
+    def test_awake_emitters_respects_max_awake_game_objects(self):
+        """With more emitters than maxAwakeGameObjects, GetAwakeEmitters only returns the awake subset."""
+        import audio2
+        maxAwake = 2
+        self.audioManager.manager.maxAwakeGameObjects = maxAwake
+
+        extraEmitterNames = ["extraEmitter%d" % index for index in range(5)]
+        # Keep references so the emitters stay registered for the duration of the test.
+        extraEmitters = []
+        for name in extraEmitterNames:
+            extraEmitter = audio2.AudEmitter(name)
+            extraEmitter.SetPlacement((0,0,0), (0,0,0), (0,0,0))
+            extraEmitters.append(extraEmitter)
+
+        allTestEmitterNames = set(extraEmitterNames) | {"awakeEmitter1"}
+
+        # Pump a few frames so CullAudio runs with the new maxAwakeGameObjects value.
+        PumpOSWithTimeout(self.alwaysTrueBoolean, maxTries=3)
+
+        awakeTestEmitters = [name for name in self.getAwakeEmitterNames() if name in allTestEmitterNames]
+        culledTestEmitters = allTestEmitterNames - set(awakeTestEmitters)
+        # The culling loop keeps maxAwakeGameObjects + 1 objects awake and the listener takes one of those slots.
+        self.assertLessEqual(len(awakeTestEmitters), maxAwake + 1)
+        self.assertGreater(len(culledTestEmitters), 0, "Expected sound prioritization to cull at least one test emitter.")
+
+    def test_awake_emitters_match_prioritized_when_culling_disabled(self):
+        """With culling disabled every game emitter is awake, so the two lists have the same members (minus built-in system objects)."""
+        systemObjectNames = {self.listener.name, "UI", "Music"}
+        self.audioManager.DisableSoundPrioritization()
+        try:
+            awakeNames = sorted(self.getAwakeEmitterNames())
+            prioritizedNames = sorted(emitter.name for emitter in self.audioManager.GetPrioritizedEmitters()
+                                      if emitter.name not in systemObjectNames)
+            self.assertEqual(awakeNames, prioritizedNames)
+        finally:
+            self.audioManager.EnableSoundPrioritization()


### PR DESCRIPTION
This pull request is in the larger context of Destiny based audio occlusion but this new API could come in handy for other things than that.

It is necessary for the client to get a list of all currently awake emitters in a production setting and not only for debug purposes. Previously, you could use GetPrioritizedEmitters but that was not something that respected the game objects mutex. GetAwakeEmitters was created to return only awake emitters in a multi-threaded safe fashion and in a way that didn't require iterating over all emitters that aren't active.