### PR TITLE
Fix false SoundBank open errors on startup

### DIFF
--- a/src/LowLevelIO/AudPathResolver.cpp
+++ b/src/LowLevelIO/AudPathResolver.cpp
@@ -129,7 +129,7 @@ AKRESULT AudPathResolver::SetAudioSrcPath(const AkOSChar* path)
     return AK_Success;
 }
 
-AKRESULT AudPathResolver::Resolve(const AkFileOpenData& request, AkOSChar* outPath)
+AKRESULT AudPathResolver::Resolve(const AkFileOpenData& request, AkOSChar* outPath, bool useLanguageFolder)
 {
     if (!outPath)
         return AK_InvalidParameter;
@@ -143,8 +143,8 @@ AKRESULT AudPathResolver::Resolve(const AkFileOpenData& request, AkOSChar* outPa
         AKPLATFORM::SafeStrCpy(fullPath, m_basePath, AK_MAX_PATH);
         AppendSeparator(fullPath);
 
-        // Language files are checked first. They only get the language folder.
-        if (request.pFlags->bIsLanguageSpecific)
+        // Localized files only get the language folder.
+        if (useLanguageFolder)
         {
             const AkOSChar* language = AK::StreamMgr::GetCurrentLanguage();
             if (AKPLATFORM::OsStrLen(language) > 0)

--- a/src/LowLevelIO/AudPathResolver.h
+++ b/src/LowLevelIO/AudPathResolver.h
@@ -29,9 +29,10 @@ public:
      * @brief Build the file path for an open request.
      * @param request The Wwise open request with its codec, file id, flags and name.
      * @param outPath Buffer of AK_MAX_PATH that receives the resolved path.
+     * @param useLanguageFolder Look under the current language folder instead of the essential or audio source folder.
      * @return AK_Success when a path was produced.
      */
-    AKRESULT Resolve(const AkFileOpenData& request, AkOSChar* outPath);
+    AKRESULT Resolve(const AkFileOpenData& request, AkOSChar* outPath, bool useLanguageFolder);
 
 private:
     AkOSChar m_basePath[AK_MAX_PATH];

--- a/src/LowLevelIO/LowLevelIOHook.cpp
+++ b/src/LowLevelIO/LowLevelIOHook.cpp
@@ -80,6 +80,15 @@ AkFileDesc* LowLevelIOHook::CreateDescriptor(const AkFileDesc* copy)
     return AkNew(AkMemID_Streaming, AkFileDesc(*copy));
 }
 
+AKRESULT LowLevelIOHook::TryOpen(const AkFileOpenData& request, bool useLanguageFolder, AkOSChar* path, AkFileDesc& fileDesc)
+{
+    AKRESULT result = m_resolver.Resolve(request, path, useLanguageFolder);
+    if (result != AK_Success)
+        return result;
+
+    return FileHelpers::Open(path, request.eOpenMode, true, fileDesc);
+}
+
 AKRESULT LowLevelIOHook::Open(const AkFileOpenData& request, AkFileDesc*& outFileDesc)
 {
     outFileDesc = CreateDescriptor();
@@ -87,9 +96,13 @@ AKRESULT LowLevelIOHook::Open(const AkFileOpenData& request, AkFileDesc*& outFil
         return AK_InsufficientMemory;
 
     AkOSChar path[AK_MAX_PATH];
-    AKRESULT result = m_resolver.Resolve(request, path);
-    if (result == AK_Success)
-        result = FileHelpers::Open(path, request.eOpenMode, true, *outFileDesc);
+    AKRESULT result = AK_FileNotFound;
+
+    if (request.pFlags && request.pFlags->bIsLanguageSpecific && request.eOpenMode == AK_OpenModeRead)
+        result = TryOpen(request, true, path, *outFileDesc);
+
+    if (result != AK_Success)
+        result = TryOpen(request, false, path, *outFileDesc);
 
     if (result == AK_Success)
     {

--- a/src/LowLevelIO/LowLevelIOHook.h
+++ b/src/LowLevelIO/LowLevelIOHook.h
@@ -54,6 +54,9 @@ private:
     // Resolve and open one file. Called per item by BatchOpen.
     AKRESULT Open(const AkFileOpenData& request, AkFileDesc*& outFileDesc);
 
+    // Resolve one candidate location and try to open it there.
+    AKRESULT TryOpen(const AkFileOpenData& request, bool useLanguageFolder, AkOSChar* path, AkFileDesc& fileDesc);
+
     AkFileDesc* CreateDescriptor(const AkFileDesc* copy = nullptr);
 
     void Read(AkFileDesc& fileDesc, const AkIoHeuristics& heuristics, AkAsyncIOTransferInfo& transfer);


### PR DESCRIPTION
## Description

This is a bug fix which stems from the recent refactor on the Low Level I/O system which was re-written right before open sourcing the engine. There is a bug report ticket [here]( https://fenriscreations.atlassian.net/browse/PLAT-11997)

### Bug diagnosis
 In low-level-io we looked for a localized copy of a soundbank first, and if the path resolver couldn't find any would log an error.
 Then it looked again in the root which would actually find the soundbanks and proceed normally.

 So in summary nothing was missing, it was a false positive spamming logs.

## Fix
`LowLevelIOHook::Open` now tries both locations in one call, the language folder first, then the normal `root/essential/media` path.

- The fallback to the default location happens only when the localized copy returned `AK_FileNotFound`. Any other error on the localized file (permission, unknown file error) is returned as is so it is not masked by the fallback.
- Each attempt resolves into its own path buffer. When both locations miss, the single error line lists both paths that were tried. When only one attempt was made, that path is logged.
