### PR TITLE
Fix false SoundBank open errors on startup

### DIFF
--- a/src/LowLevelIO/AudPathResolver.cpp
+++ b/src/LowLevelIO/AudPathResolver.cpp
@@ -129,7 +129,7 @@ AKRESULT AudPathResolver::SetAudioSrcPath(const AkOSChar* path)
     return AK_Success;
 }
 
-AKRESULT AudPathResolver::Resolve(const AkFileOpenData& request, AkOSChar* outPath)
+AKRESULT AudPathResolver::Resolve(const AkFileOpenData& request, AkOSChar* outPath, bool useLanguageFolder)
 {
     if (!outPath)
         return AK_InvalidParameter;
@@ -143,8 +143,8 @@ AKRESULT AudPathResolver::Resolve(const AkFileOpenData& request, AkOSChar* outPa
         AKPLATFORM::SafeStrCpy(fullPath, m_basePath, AK_MAX_PATH);
         AppendSeparator(fullPath);
 
-        // Language files are checked first. They only get the language folder.
-        if (request.pFlags->bIsLanguageSpecific)
+        // Localized files only get the language folder.
+        if (useLanguageFolder)
         {
             const AkOSChar* language = AK::StreamMgr::GetCurrentLanguage();
             if (AKPLATFORM::OsStrLen(language) > 0)

--- a/src/LowLevelIO/AudPathResolver.h
+++ b/src/LowLevelIO/AudPathResolver.h
@@ -29,9 +29,10 @@ public:
      * @brief Build the file path for an open request.
      * @param request The Wwise open request with its codec, file id, flags and name.
      * @param outPath Buffer of AK_MAX_PATH that receives the resolved path.
+     * @param useLanguageFolder Look under the current language folder instead of the essential or audio source folder.
      * @return AK_Success when a path was produced.
      */
-    AKRESULT Resolve(const AkFileOpenData& request, AkOSChar* outPath);
+    AKRESULT Resolve(const AkFileOpenData& request, AkOSChar* outPath, bool useLanguageFolder);
 
 private:
     AkOSChar m_basePath[AK_MAX_PATH];

--- a/src/LowLevelIO/LowLevelIOHook.cpp
+++ b/src/LowLevelIO/LowLevelIOHook.cpp
@@ -13,6 +13,13 @@
 #include <stdio.h>
 #endif
 
+// printf spec for AkOSChar strings in CCP log calls.
+#if defined(_WIN32)
+#define AUD_OSCHAR_FMT "%S"
+#else
+#define AUD_OSCHAR_FMT "%s"
+#endif
+
 namespace
 {
 #if defined(_WIN32)
@@ -95,13 +102,18 @@ AKRESULT LowLevelIOHook::Open(const AkFileOpenData& request, AkFileDesc*& outFil
     if (!outFileDesc)
         return AK_InsufficientMemory;
 
-    AkOSChar path[AK_MAX_PATH];
-    AKRESULT result = AK_FileNotFound;
+    // Localized files fall back to the default location only when the localized copy does not exist.
+    const bool tryLanguage = request.pFlags && request.pFlags->bIsLanguageSpecific && request.eOpenMode == AK_OpenModeRead;
 
-    if (request.pFlags && request.pFlags->bIsLanguageSpecific && request.eOpenMode == AK_OpenModeRead)
-        result = TryOpen(request, true, path, *outFileDesc);
+    AkOSChar languagePath[AK_MAX_PATH] = { 0 };
+    AkOSChar path[AK_MAX_PATH] = { 0 };
+    AKRESULT result = AK_Fail;
 
-    if (result != AK_Success)
+    if (tryLanguage)
+        result = TryOpen(request, true, languagePath, *outFileDesc);
+
+    const bool tryDefault = !tryLanguage || result == AK_FileNotFound;
+    if (tryDefault)
         result = TryOpen(request, false, path, *outFileDesc);
 
     if (result == AK_Success)
@@ -110,13 +122,12 @@ AKRESULT LowLevelIOHook::Open(const AkFileOpenData& request, AkFileDesc*& outFil
         return AK_Success;
     }
 
-#if defined(_WIN32)
-    CCP_LOGERR("Failed to open audio file (id %u, path '%S'): result %d",
-        (unsigned int)request.fileID, path, result);
-#else
-    CCP_LOGERR("Failed to open audio file (id %u, path '%s'): result %d",
-        (unsigned int)request.fileID, path, result);
-#endif
+    if (tryLanguage && tryDefault)
+        CCP_LOGERR("Failed to open audio file (id %u): result %d, tried '" AUD_OSCHAR_FMT "' and '" AUD_OSCHAR_FMT "'",
+            (unsigned int)request.fileID, result, languagePath, path);
+    else
+        CCP_LOGERR("Failed to open audio file (id %u, path '" AUD_OSCHAR_FMT "'): result %d",
+            (unsigned int)request.fileID, tryLanguage ? languagePath : path, result);
 
     AkDelete(AkMemID_Streaming, outFileDesc);
     outFileDesc = nullptr;

--- a/src/LowLevelIO/LowLevelIOHook.cpp
+++ b/src/LowLevelIO/LowLevelIOHook.cpp
@@ -80,6 +80,15 @@ AkFileDesc* LowLevelIOHook::CreateDescriptor(const AkFileDesc* copy)
     return AkNew(AkMemID_Streaming, AkFileDesc(*copy));
 }
 
+AKRESULT LowLevelIOHook::TryOpen(const AkFileOpenData& request, bool useLanguageFolder, AkOSChar* path, AkFileDesc& fileDesc)
+{
+    AKRESULT result = m_resolver.Resolve(request, path, useLanguageFolder);
+    if (result != AK_Success)
+        return result;
+
+    return FileHelpers::Open(path, request.eOpenMode, true, fileDesc);
+}
+
 AKRESULT LowLevelIOHook::Open(const AkFileOpenData& request, AkFileDesc*& outFileDesc)
 {
     outFileDesc = CreateDescriptor();
@@ -87,9 +96,13 @@ AKRESULT LowLevelIOHook::Open(const AkFileOpenData& request, AkFileDesc*& outFil
         return AK_InsufficientMemory;
 
     AkOSChar path[AK_MAX_PATH];
-    AKRESULT result = m_resolver.Resolve(request, path);
-    if (result == AK_Success)
-        result = FileHelpers::Open(path, request.eOpenMode, true, *outFileDesc);
+    AKRESULT result = AK_FileNotFound;
+
+    if (request.pFlags && request.pFlags->bIsLanguageSpecific && request.eOpenMode == AK_OpenModeRead)
+        result = TryOpen(request, true, path, *outFileDesc);
+
+    if (result != AK_Success)
+        result = TryOpen(request, false, path, *outFileDesc);
 
     if (result == AK_Success)
     {

--- a/src/LowLevelIO/LowLevelIOHook.cpp
+++ b/src/LowLevelIO/LowLevelIOHook.cpp
@@ -110,11 +110,15 @@ AKRESULT LowLevelIOHook::Open(const AkFileOpenData& request, AkFileDesc*& outFil
     AKRESULT result = AK_Fail;
 
     if (tryLanguage)
+    {
         result = TryOpen(request, true, languagePath, *outFileDesc);
+    }
 
     const bool tryDefault = !tryLanguage || result == AK_FileNotFound;
     if (tryDefault)
+    {
         result = TryOpen(request, false, path, *outFileDesc);
+    }
 
     if (result == AK_Success)
     {
@@ -123,11 +127,15 @@ AKRESULT LowLevelIOHook::Open(const AkFileOpenData& request, AkFileDesc*& outFil
     }
 
     if (tryLanguage && tryDefault)
+    {
         CCP_LOGERR("Failed to open audio file (id %u): result %d, tried '" AUD_OSCHAR_FMT "' and '" AUD_OSCHAR_FMT "'",
             (unsigned int)request.fileID, result, languagePath, path);
+    }
     else
+    {
         CCP_LOGERR("Failed to open audio file (id %u, path '" AUD_OSCHAR_FMT "'): result %d",
             (unsigned int)request.fileID, tryLanguage ? languagePath : path, result);
+    }
 
     AkDelete(AkMemID_Streaming, outFileDesc);
     outFileDesc = nullptr;

--- a/src/LowLevelIO/LowLevelIOHook.h
+++ b/src/LowLevelIO/LowLevelIOHook.h
@@ -54,6 +54,9 @@ private:
     // Resolve and open one file. Called per item by BatchOpen.
     AKRESULT Open(const AkFileOpenData& request, AkFileDesc*& outFileDesc);
 
+    // Resolve one candidate location and try to open it there.
+    AKRESULT TryOpen(const AkFileOpenData& request, bool useLanguageFolder, AkOSChar* path, AkFileDesc& fileDesc);
+
     AkFileDesc* CreateDescriptor(const AkFileDesc* copy = nullptr);
 
     void Read(AkFileDesc& fileDesc, const AkIoHeuristics& heuristics, AkAsyncIOTransferInfo& transfer);


### PR DESCRIPTION
## Description

This is a bug fix which stems from the recent refactor on the Low Level I/O system which was re-written right before open sourcing the engine. There is a bug report ticket [here]( https://fenriscreations.atlassian.net/browse/PLAT-11997)

### Bug diagnosis
 In low-level-io we looked for a localized copy of a soundbank first, and if the path resolver couldn't find any would log an error.
 Then it looked again in the root which would actually find the soundbanks and proceed normally.

 So in summary nothing was missing, it was a false positive spamming logs.

## Fix
`LowLevelIOHook::Open` tries the language folder first, then the default location, in a single call, so the expected miss on the language folder no longer logs an error.

- Fallback only on `AK_FileNotFound`. Any other error on the localized file is returned as is.
- Each attempt has its own path buffer. If both miss, the error line lists both paths.